### PR TITLE
Add shared user persistence layer

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -73,9 +73,10 @@ These are explicit API contracts. Even for small endpoints, the repository prefe
 - PostgreSQL is the only database
 - Flyway owns schema migration
 - Spring Data JPA is available on the classpath
-- no entities or repositories have been added yet
+- `User` is the first JPA entity and maps to the `users` table
+- `UserRepository` is the first Spring Data repository and supports account lookups by email
 
-At the moment, database access exists only for runtime readiness checks. There is no domain persistence layer because there are no domain features yet.
+At the moment, the persistence layer supports shared account storage for authentication-related features. More domain entities and repositories should follow the same package and layering conventions.
 
 ## Folder Structure
 
@@ -86,6 +87,8 @@ src/
 |  |  |- config/
 |  |  |- controller/
 |  |  |- dto/
+|  |  |- model/
+|  |  |- repository/
 |  |  |- service/
 |  |  `- MageBackendApplication.java
 |  `- resources/
@@ -95,6 +98,7 @@ src/
    `- java/com/bdmage/mage_backend/
       |- config/
       |- controller/
+      |- repository/
       |- service/
       |- support/
       `- MageBackendApplicationTests.java
@@ -104,6 +108,8 @@ src/
 - `controller/` is for HTTP entry points
 - `service/` is for business or application logic
 - `dto/` is for public request and response contracts
+- `model/` is for JPA entities and domain objects
+- `repository/` is for persistence interfaces and query intent
 - `resources/db/migration/` is for schema evolution
 - `test/support/` is for reusable testing infrastructure
 
@@ -142,8 +148,6 @@ As a result, the expected way to change the schema is straightforward:
 
 The codebase does not currently include:
 
-- domain entities
-- repository interfaces
 - authentication or authorization
 - request validation beyond current simple endpoints
 

--- a/src/main/java/com/bdmage/mage_backend/model/User.java
+++ b/src/main/java/com/bdmage/mage_backend/model/User.java
@@ -1,0 +1,60 @@
+package com.bdmage.mage_backend.model;
+
+import java.time.Instant;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "users")
+public class User {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "email", nullable = false, length = 320)
+	private String email;
+
+	@Column(name = "password_hash", nullable = false, length = 255)
+	private String passwordHash;
+
+	@Column(name = "display_name", nullable = false, length = 100)
+	private String displayName;
+
+	@Column(name = "created_at", nullable = false, insertable = false, updatable = false)
+	private Instant createdAt;
+
+	protected User() {
+	}
+
+	public User(String email, String passwordHash, String displayName) {
+		this.email = email;
+		this.passwordHash = passwordHash;
+		this.displayName = displayName;
+	}
+
+	public Long getId() {
+		return this.id;
+	}
+
+	public String getEmail() {
+		return this.email;
+	}
+
+	public String getPasswordHash() {
+		return this.passwordHash;
+	}
+
+	public String getDisplayName() {
+		return this.displayName;
+	}
+
+	public Instant getCreatedAt() {
+		return this.createdAt;
+	}
+}

--- a/src/main/java/com/bdmage/mage_backend/repository/UserRepository.java
+++ b/src/main/java/com/bdmage/mage_backend/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.bdmage.mage_backend.repository;
+
+import java.util.Optional;
+
+import com.bdmage.mage_backend.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+	Optional<User> findByEmail(String email);
+}

--- a/src/test/java/com/bdmage/mage_backend/repository/UserRepositoryIntegrationTests.java
+++ b/src/test/java/com/bdmage/mage_backend/repository/UserRepositoryIntegrationTests.java
@@ -1,0 +1,51 @@
+package com.bdmage.mage_backend.repository;
+
+import com.bdmage.mage_backend.model.User;
+import com.bdmage.mage_backend.support.PostgresIntegrationTestSupport;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SpringBootTest
+@Testcontainers
+class UserRepositoryIntegrationTests extends PostgresIntegrationTestSupport {
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@PersistenceContext
+	private EntityManager entityManager;
+
+	@Test
+	void savePersistsUserAndFindByEmailReturnsStoredRecord() {
+		String email = "user-" + System.nanoTime() + "@example.com";
+		User savedUser = userRepository.saveAndFlush(new User(email, "hashed-password-value", "Test User"));
+
+		entityManager.clear();
+
+		User foundUser = userRepository.findByEmail(email).orElseThrow();
+
+		assertThat(savedUser.getId()).isNotNull();
+		assertThat(foundUser.getId()).isEqualTo(savedUser.getId());
+		assertThat(foundUser.getEmail()).isEqualTo(email);
+		assertThat(foundUser.getPasswordHash()).isEqualTo("hashed-password-value");
+		assertThat(foundUser.getDisplayName()).isEqualTo("Test User");
+		assertThat(foundUser.getCreatedAt()).isNotNull();
+	}
+
+	@Test
+	void findByEmailReturnsEmptyWhenNoUserMatches() {
+		String missingEmail = "missing-" + System.nanoTime() + "@example.com";
+
+		assertThat(userRepository.findByEmail(missingEmail)).isEmpty();
+	}
+}


### PR DESCRIPTION
## Summary

- add a `User` JPA entity mapped to the existing `users` table
- add a Spring Data `UserRepository` with `findByEmail(String)` and standard save support
- add integration tests covering user save/persist and lookup-by-email behavior against Flyway-managed PostgreSQL
- update the architecture docs to reflect the new `model` and `repository` packages

## Testing

- `.\mvnw.cmd test`