### PR TITLE
Allow public preset detail reads

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -102,7 +102,7 @@ Endpoints:
 
 `POST /presets/{id}/tags` runs behind authentication middleware. The middleware validates the bearer token, places the authenticated user in request context, and the controller delegates preset/tag association rules to the service layer so tagging and discovery features share one persistence path.
 
-`GET /presets/{id}` runs behind authentication middleware. The middleware validates the bearer token before the controller delegates preset lookup to the service layer and returns the preset metadata, scene data, thumbnail reference, and creation timestamp when the preset exists.
+`GET /presets/{id}` is public. The controller delegates preset lookup to the service layer and returns the preset metadata, scene data, thumbnail reference, and creation timestamp when the preset exists.
 
 `DELETE /presets/{id}` runs behind authentication middleware. The middleware validates the bearer token, places the authenticated user in request context, and the controller delegates owner-only deletion rules to the service layer. The service rejects non-owner deletes with `403 Forbidden` and removes the preset through the shared persistence path, which also clears dependent preset/tag links through database cascading.
 
@@ -282,7 +282,7 @@ The codebase does not currently include:
 - logout or token revocation
 - token expiration
 
-Successful `POST /auth/login` and `POST /auth/google` requests issue bearer access tokens. Bearer-token authentication currently protects `GET /users/me`, `POST /presets`, `GET /presets`, `POST /presets/{id}/tags`, `GET /presets/{id}`, `DELETE /presets/{id}`, and `GET /users/{id}/presets`.
+Successful `POST /auth/login` and `POST /auth/google` requests issue bearer access tokens. Bearer-token authentication currently protects `GET /users/me`, `POST /presets`, `GET /presets`, `POST /presets/{id}/tags`, `DELETE /presets/{id}`, and `GET /users/{id}/presets`, while `GET /presets/{id}` remains public.
 
 ## Target Architecture as the Backend Grows
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -98,7 +98,7 @@ Expected responses:
 - `POST /presets` returns `201 Created` with the created preset fields when the request includes `Authorization: Bearer <accessToken>`
 - `GET /presets` returns `200 OK` with an array of presets when the request includes `Authorization: Bearer <accessToken>`, and `GET /presets?tag=ambient` returns only presets linked to that tag or an empty array when none match
 - `POST /presets/{presetId}/tags` returns `201 Created` with the preset/tag association fields when the request includes `Authorization: Bearer <accessToken>` and both records exist
-- `GET /presets/{presetId}` returns `200 OK` with the preset metadata, scene data, thumbnail reference, and creation timestamp when the request includes `Authorization: Bearer <accessToken>` and the preset exists
+- `GET /presets/{presetId}` returns `200 OK` with the preset metadata, scene data, thumbnail reference, and creation timestamp when the preset exists, even without an `Authorization` header
 - `DELETE /presets/{presetId}` returns `204 No Content` when the request includes `Authorization: Bearer <accessToken>` and the authenticated user owns the preset, `403 Forbidden` when a different authenticated user tries to delete it, and `404 Not Found` when the preset does not exist
 - `GET /users/{id}/presets` returns `200 OK` with an array of presets for the requested user when the request includes `Authorization: Bearer <accessToken>`
 
@@ -138,8 +138,7 @@ Use the `accessToken` from the login response or Google auth response when calli
       -H "Content-Type: application/json" \
       -d '{"tagId":<tag-id>}'
 
-    curl http://localhost:8080/presets/<preset-id> \
-      -H "Authorization: Bearer <access-token>"
+    curl http://localhost:8080/presets/<preset-id>
 
     curl -X DELETE http://localhost:8080/presets/<preset-id> \
       -H "Authorization: Bearer <access-token>"
@@ -258,7 +257,7 @@ If you are new to the repository, this sequence builds the fastest mental model 
 15. trace `POST /presets` from authentication middleware to controller to service to repository
 16. trace `GET /presets` from authentication middleware to controller to service to repository, including the optional `tag` query parameter path
 17. trace `POST /presets/{id}/tags` from authentication middleware to controller to service to repository
-18. trace `GET /presets/{id}` from authentication middleware to controller to service to repository
+18. trace public `GET /presets/{id}` from the controller to the service to the repository
 19. trace `DELETE /presets/{id}` from authentication middleware to controller to service, including the owner-only authorization check
 20. trace `GET /users/{id}/presets` from authentication middleware to controller to service to repository
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -22,7 +22,7 @@ Operationally important behavior:
 - Google ID tokens are verified server-side against `MAGE_AUTH_GOOGLE_CLIENT_IDS`
 - successful `POST /auth/login` and `POST /auth/google` requests issue bearer access tokens
 - local and Google auth providers can be linked explicitly, but never auto-linked only because emails match
-- authentication middleware validates bearer tokens for protected `/users/**` and `/presets/**` endpoints and stores the authenticated user in request context
+- authentication middleware validates bearer tokens for protected `/users/**` endpoints and protected preset routes, while `GET /presets/{id}` remains public
 
 ## Local Startup Runbook
 
@@ -372,16 +372,16 @@ Purpose:
 
 Request notes:
 
-- requires an `Authorization: Bearer <accessToken>` header using a token issued by `POST /auth/login` or `POST /auth/google`
+- does not require authentication
+- ignores missing bearer tokens and returns preset data when the preset exists
 
 Success behavior:
 
-- HTTP `200 OK` for a valid authenticated request when the preset exists
+- HTTP `200 OK` when the preset exists
 - response includes the preset id, owner user id, preset metadata, scene data, thumbnail reference, and creation timestamp
 
 Failure behavior:
 
-- HTTP `401 Unauthorized` when the request is missing a bearer token, uses an invalid token, or the token points to a user record that no longer exists
 - HTTP `404 Not Found` when no preset exists for the supplied id
 
 ### `DELETE /presets/{id}`
@@ -444,7 +444,7 @@ After startup, verify these items in order:
 13. `POST /presets` succeeds when called with `Authorization: Bearer <accessToken>` and a valid preset payload
 14. `GET /presets` succeeds when called with `Authorization: Bearer <accessToken>` and returns either all presets, only presets matching `?tag=<name>`, or an empty array when no presets match
 15. `POST /presets/{id}/tags` succeeds when called with `Authorization: Bearer <accessToken>`, an existing preset id, and an existing tag id
-16. `GET /presets/{id}` succeeds when called with `Authorization: Bearer <accessToken>` and an existing preset id
+16. `GET /presets/{id}` succeeds for public requests and returns the preset when the id exists
 17. `DELETE /presets/{id}` succeeds when called with `Authorization: Bearer <accessToken>` by the preset owner and returns `204 No Content`
 18. `GET /users/{id}/presets` succeeds when called with `Authorization: Bearer <accessToken>` and returns either preset records or an empty array
 
@@ -628,12 +628,6 @@ Interpretation:
 
 - the request was missing a bearer token, the token was invalid, or the token points to a user record that no longer exists
 
-### `GET /presets/{id}` returns `401`
-
-Interpretation:
-
-- the request was missing a bearer token, the token was invalid, or the token points to a user record that no longer exists
-
 ### `DELETE /presets/{id}` returns `401`
 
 Interpretation:
@@ -650,7 +644,7 @@ Interpretation:
 
 Interpretation:
 
-- the request was authenticated successfully, but no preset exists for that id
+- no preset exists for that id, regardless of whether the caller is signed in
 
 ### `DELETE /presets/{id}` returns `403`
 

--- a/src/main/java/com/bdmage/mage_backend/config/AuthenticationInterceptor.java
+++ b/src/main/java/com/bdmage/mage_backend/config/AuthenticationInterceptor.java
@@ -6,7 +6,9 @@ import com.bdmage.mage_backend.service.AuthenticationTokenService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.util.StringUtils;
 import org.springframework.web.servlet.HandlerInterceptor;
 
@@ -15,6 +17,8 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
 
 	private static final String AUTHENTICATION_REQUIRED_MESSAGE = "Authentication is required.";
 	private static final String BEARER_PREFIX = "Bearer ";
+	private static final String PUBLIC_PRESET_DETAIL_PATTERN = "/presets/{id}";
+	private static final AntPathMatcher PATH_MATCHER = new AntPathMatcher();
 
 	private final AuthenticationTokenService authenticationTokenService;
 
@@ -24,10 +28,32 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
 
 	@Override
 	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+		// Public preset detail pages allow anonymous GET /presets/{id} reads without
+		// opening write or owner-sensitive preset routes.
+		if (isPublicPresetDetailRequest(request)) {
+			return true;
+		}
+
 		String token = resolveBearerToken(request);
 		User authenticatedUser = this.authenticationTokenService.authenticate(token);
 		AuthenticatedUserRequest.authenticate(request, authenticatedUser);
 		return true;
+	}
+
+	private static boolean isPublicPresetDetailRequest(HttpServletRequest request) {
+		return HttpMethod.GET.matches(request.getMethod())
+				&& PATH_MATCHER.match(PUBLIC_PRESET_DETAIL_PATTERN, pathWithinApplication(request));
+	}
+
+	private static String pathWithinApplication(HttpServletRequest request) {
+		String requestUri = request.getRequestURI();
+		String contextPath = request.getContextPath();
+
+		if (StringUtils.hasText(contextPath) && requestUri.startsWith(contextPath)) {
+			return requestUri.substring(contextPath.length());
+		}
+
+		return requestUri;
 	}
 
 	private static String resolveBearerToken(HttpServletRequest request) {

--- a/src/test/java/com/bdmage/mage_backend/config/AuthenticationInterceptorTests.java
+++ b/src/test/java/com/bdmage/mage_backend/config/AuthenticationInterceptorTests.java
@@ -50,6 +50,33 @@ class AuthenticationInterceptorTests {
 	}
 
 	@Test
+	void preHandleAllowsPublicPresetDetailRequestWithoutAuthenticationHeader() {
+		AuthenticationTokenService authenticationTokenService = mock(AuthenticationTokenService.class);
+		AuthenticationInterceptor interceptor = new AuthenticationInterceptor(authenticationTokenService);
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/presets/15");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		assertThat(interceptor.preHandle(request, response, new Object())).isTrue();
+		assertThat(request.getAttribute(AuthenticatedUserRequest.USER_ATTRIBUTE)).isNull();
+		assertThat(request.getAttribute(AuthenticatedUserRequest.USER_ID_ATTRIBUTE)).isNull();
+		verifyNoInteractions(authenticationTokenService);
+	}
+
+	@Test
+	void preHandleStillRejectsDeletePresetRequestWithoutAuthenticationHeader() {
+		AuthenticationTokenService authenticationTokenService = mock(AuthenticationTokenService.class);
+		AuthenticationInterceptor interceptor = new AuthenticationInterceptor(authenticationTokenService);
+		MockHttpServletRequest request = new MockHttpServletRequest("DELETE", "/presets/15");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		assertThatThrownBy(() -> interceptor.preHandle(request, response, new Object()))
+				.isInstanceOf(AuthenticationRequiredException.class)
+				.hasMessage("Authentication is required.");
+
+		verifyNoInteractions(authenticationTokenService);
+	}
+
+	@Test
 	void preHandleRejectsBlankBearerToken() {
 		AuthenticationTokenService authenticationTokenService = mock(AuthenticationTokenService.class);
 		AuthenticationInterceptor interceptor = new AuthenticationInterceptor(authenticationTokenService);

--- a/src/test/java/com/bdmage/mage_backend/controller/PresetControllerIntegrationTests.java
+++ b/src/test/java/com/bdmage/mage_backend/controller/PresetControllerIntegrationTests.java
@@ -367,12 +367,33 @@ class PresetControllerIntegrationTests extends PostgresIntegrationTestSupport {
 	}
 
 	@Test
-	void getPresetReturnsUnauthorizedWhenRequestHasNoAuthenticationHeader() throws Exception {
-		this.mockMvc.perform(get("/presets/99999")
+	void getPresetReturnsPresetWithAllFieldsForPublicRequest() throws Exception {
+		String uniqueSuffix = String.valueOf(System.nanoTime());
+		String email = "public-get-preset-user-" + uniqueSuffix + "@example.com";
+
+		User savedUser = this.userRepository.saveAndFlush(new User(
+				email,
+				this.passwordHashingService.hash("unused-password-" + uniqueSuffix),
+				"Public Get Preset User"));
+
+		Preset savedPreset = this.presetRepository.saveAndFlush(new Preset(
+				savedUser.getId(),
+				"Aurora Drift",
+				this.objectMapper.readTree("""
+						{"visualizer":{"shader":"nebula"},"state":{"energy":0.92}}
+						"""),
+				"thumbnails/preset-1.png"));
+
+		this.mockMvc.perform(get("/presets/" + savedPreset.getId())
 				.contentType(MediaType.APPLICATION_JSON))
-				.andExpect(status().isUnauthorized())
-				.andExpect(jsonPath("$.code").value("AUTHENTICATION_REQUIRED"))
-				.andExpect(jsonPath("$.message").value("Authentication is required."));
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.presetId").value(savedPreset.getId()))
+				.andExpect(jsonPath("$.ownerUserId").value(savedUser.getId()))
+				.andExpect(jsonPath("$.name").value("Aurora Drift"))
+				.andExpect(jsonPath("$.sceneData.visualizer.shader").value("nebula"))
+				.andExpect(jsonPath("$.sceneData.state.energy").value(0.92))
+				.andExpect(jsonPath("$.thumbnailRef").value("thumbnails/preset-1.png"))
+				.andExpect(jsonPath("$.createdAt").isNotEmpty());
 	}
 
 	@Test
@@ -415,25 +436,8 @@ class PresetControllerIntegrationTests extends PostgresIntegrationTestSupport {
 	}
 
 	@Test
-	void getPresetReturnsNotFoundForNonexistentPreset() throws Exception {
-		String uniqueSuffix = String.valueOf(System.nanoTime());
-		String email = "missing-preset-user-" + uniqueSuffix + "@example.com";
-		String password = "password-" + uniqueSuffix;
-
-		this.userRepository.saveAndFlush(new User(
-				email,
-				this.passwordHashingService.hash(password),
-				"Missing Preset User"));
-
-		String accessToken = accessToken(this.mockMvc.perform(post("/auth/login")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(loginRequestBody(email, password)))
-				.andExpect(status().isOk())
-				.andExpect(jsonPath("$.accessToken").isNotEmpty())
-				.andReturn());
-
+	void getPresetReturnsNotFoundForPublicRequestWhenPresetDoesNotExist() throws Exception {
 		this.mockMvc.perform(get("/presets/99999")
-				.header("Authorization", "Bearer " + accessToken)
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isNotFound())
 				.andExpect(jsonPath("$.code").value("PRESET_NOT_FOUND"))


### PR DESCRIPTION
## Summary
- allow anonymous `GET /presets/{id}` requests for public preset detail/player pages
- keep protected preset and user routes behind authentication
- update backend tests and docs to reflect the new auth boundary

## Problem
The frontend preset detail/player page is meant to support direct public viewing, but the backend authentication middleware was still blocking `GET /presets/{id}` unless the request included a bearer token. That prevented signed-out users from loading preset detail routes directly.

## What Changed
- added a narrow authentication bypass for `GET /presets/{id}` in the backend interceptor
- kept auth enforcement in place for:
  - `POST /presets`
  - `GET /presets`
  - `POST /presets/{id}/tags`
  - `DELETE /presets/{id}`
  - `GET /users/{id}/presets`
- updated interceptor tests to verify:
  - anonymous preset-detail GET requests are allowed
  - delete requests without auth are still rejected
- updated preset integration tests to verify:
  - public preset detail reads return `200 OK` when the preset exists
  - public preset detail reads return `404 Not Found` when the preset does not exist
- updated backend docs to mark `GET /presets/{id}` as public

## Testing
- mvn "-Dtest=AuthenticationInterceptorTests,PresetControllerIntegrationTests,UserControllerIntegrationTests" test

## Notes
- this fixes the backend auth gate for public preset detail reads
- direct browser hits to `/presets/:id` in the frontend dev server still need the frontend/API route collision to be handled separately
