### PR TITLE
Namespace backend routes under /api

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,19 +43,19 @@ Once the stack is healthy:
 - backend: `http://localhost:8080`
 - liveness: `http://localhost:8080/health`
 - readiness: `http://localhost:8080/ready`
-- local registration: `POST http://localhost:8080/auth/register`
-- local login: `POST http://localhost:8080/auth/login`
-- Google auth: `POST http://localhost:8080/auth/google`
-- link Google to an existing local account: `POST http://localhost:8080/auth/link/google`
-- link local auth to an existing Google-backed account: `POST http://localhost:8080/auth/link/local`
-- current user profile: `GET http://localhost:8080/users/me`
-- preset creation: `POST http://localhost:8080/presets`
-- preset list: `GET http://localhost:8080/presets`
-- preset list filtered by tag: `GET http://localhost:8080/presets?tag=ambient`
-- preset detail: `GET http://localhost:8080/presets/{id}`
-- preset deletion: `DELETE http://localhost:8080/presets/{id}`
-- preset tag attachment: `POST http://localhost:8080/presets/{id}/tags`
-- user preset list: `GET http://localhost:8080/users/{id}/presets`
+- local registration: `POST http://localhost:8080/api/auth/register`
+- local login: `POST http://localhost:8080/api/auth/login`
+- Google auth: `POST http://localhost:8080/api/auth/google`
+- link Google to an existing local account: `POST http://localhost:8080/api/auth/link/google`
+- link local auth to an existing Google-backed account: `POST http://localhost:8080/api/auth/link/local`
+- current user profile: `GET http://localhost:8080/api/users/me`
+- preset creation: `POST http://localhost:8080/api/presets`
+- preset list: `GET http://localhost:8080/api/presets`
+- preset list filtered by tag: `GET http://localhost:8080/api/presets?tag=ambient`
+- preset detail: `GET http://localhost:8080/api/presets/{id}`
+- preset deletion: `DELETE http://localhost:8080/api/presets/{id}`
+- preset tag attachment: `POST http://localhost:8080/api/presets/{id}/tags`
+- user preset list: `GET http://localhost:8080/api/users/{id}/presets`
 
 Run the test suite with:
 
@@ -127,3 +127,5 @@ mage-backend/
 - [docs/engineering-standards.md](docs/engineering-standards.md): coding, API, persistence, testing, logging, security, and collaboration standards
 - [docs/operations.md](docs/operations.md): operational runbook for Docker, health checks, authentication and linking behavior, logs, migrations, and troubleshooting
 - [CONTRIBUTING.md](CONTRIBUTING.md): pull request and contribution workflow
+
+

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,7 +5,7 @@ Today the backend is responsible for:
 - starting the Spring Boot application
 - building and validating the PostgreSQL datasource
 - applying Flyway migrations on startup
-- exposing `/health`, `/ready`, `POST /auth/register`, `POST /auth/login`, `POST /auth/google`, `POST /auth/link/google`, `POST /auth/link/local`, `GET /users/me`, `POST /tags`, `POST /presets`, `GET /presets`, `POST /presets/{id}/tags`, `GET /presets/{id}`, `DELETE /presets/{id}`, and `GET /users/{id}/presets`
+- exposing `/health`, `/ready`, `POST /api/auth/register`, `POST /api/auth/login`, `POST /api/auth/google`, `POST /api/auth/link/google`, `POST /api/auth/link/local`, `GET /api/users/me`, `POST /api/tags`, `POST /api/presets`, `GET /api/presets`, `POST /api/presets/{id}/tags`, `GET /api/presets/{id}`, `DELETE /api/presets/{id}`, and `GET /api/users/{id}/presets`
 - registering local email-and-password accounts through the shared `users` table
 - authenticating local email-and-password accounts through the shared `users` table
 - verifying Google ID tokens server-side against configured Google OAuth client IDs
@@ -64,49 +64,49 @@ Endpoints:
 
 - `GET /health`
 - `GET /ready`
-- `POST /auth/register`
-- `POST /auth/login`
-- `POST /auth/google`
-- `POST /auth/link/google`
-- `POST /auth/link/local`
-- `GET /users/me`
-- `POST /tags`
-- `POST /presets`
-- `GET /presets`
-- `POST /presets/{id}/tags`
-- `GET /presets/{id}`
-- `DELETE /presets/{id}`
-- `GET /users/{id}/presets`
+- `POST /api/auth/register`
+- `POST /api/auth/login`
+- `POST /api/auth/google`
+- `POST /api/auth/link/google`
+- `POST /api/auth/link/local`
+- `GET /api/users/me`
+- `POST /api/tags`
+- `POST /api/presets`
+- `GET /api/presets`
+- `POST /api/presets/{id}/tags`
+- `GET /api/presets/{id}`
+- `DELETE /api/presets/{id}`
+- `GET /api/users/{id}/presets`
 
 `/health` is a liveness check. It answers the narrow question, "Is the process up?"
 
 `/ready` is a readiness check. It answers the more operationally useful question, "Can this instance actually serve traffic right now?"
 
-`POST /auth/google` accepts a Google ID token, delegates token verification to the service layer, and returns either a created or reused Google-backed user record plus a bearer access token.
+`POST /api/auth/google` accepts a Google ID token, delegates token verification to the service layer, and returns either a created or reused Google-backed user record plus a bearer access token.
 
-`POST /auth/register` accepts email, password, and display name, delegates registration rules to the service layer, and returns a created local account without exposing password material.
+`POST /api/auth/register` accepts email, password, and display name, delegates registration rules to the service layer, and returns a created local account without exposing password material.
 
-`POST /auth/login` accepts email and password, delegates credential verification to the service layer, and returns the authenticated local account plus a bearer access token without exposing password material.
+`POST /api/auth/login` accepts email and password, delegates credential verification to the service layer, and returns the authenticated local account plus a bearer access token without exposing password material.
 
-`POST /auth/link/google` accepts a local email/password pair plus a Google ID token and only links the provider after both ownership checks succeed.
+`POST /api/auth/link/google` accepts a local email/password pair plus a Google ID token and only links the provider after both ownership checks succeed.
 
-`POST /auth/link/local` accepts a Google ID token plus a new password and only links local auth after the Google-backed account context is verified.
+`POST /api/auth/link/local` accepts a Google ID token plus a new password and only links local auth after the Google-backed account context is verified.
 
-`GET /users/me` runs behind authentication middleware. The middleware validates the bearer token, places the authenticated user in request context, and the controller delegates profile lookup to the service layer without exposing password hashes or Google subject identifiers.
+`GET /api/users/me` runs behind authentication middleware. The middleware validates the bearer token, places the authenticated user in request context, and the controller delegates profile lookup to the service layer without exposing password hashes or Google subject identifiers.
 
-`POST /tags` accepts a tag name, delegates normalization and duplicate-tag checks to the service layer, and stores new tags through the shared `tags` table.
+`POST /api/tags` accepts a tag name, delegates normalization and duplicate-tag checks to the service layer, and stores new tags through the shared `tags` table.
 
-`POST /presets` runs behind authentication middleware. The middleware validates the bearer token, places the authenticated user in request context, and the controller delegates preset persistence to the service layer so future preset features share one creation path.
+`POST /api/presets` runs behind authentication middleware. The middleware validates the bearer token, places the authenticated user in request context, and the controller delegates preset persistence to the service layer so future preset features share one creation path.
 
-`GET /presets` runs behind authentication middleware. The middleware validates the bearer token before the controller delegates preset lookup to the service layer. Without a `tag` query parameter it returns all persisted presets, and with `?tag=<name>` it returns only presets linked to that normalized tag name.
+`GET /api/presets` runs behind authentication middleware. The middleware validates the bearer token before the controller delegates preset lookup to the service layer. Without a `tag` query parameter it returns all persisted presets, and with `?tag=<name>` it returns only presets linked to that normalized tag name.
 
-`POST /presets/{id}/tags` runs behind authentication middleware. The middleware validates the bearer token, places the authenticated user in request context, and the controller delegates preset/tag association rules to the service layer so tagging and discovery features share one persistence path.
+`POST /api/presets/{id}/tags` runs behind authentication middleware. The middleware validates the bearer token, places the authenticated user in request context, and the controller delegates preset/tag association rules to the service layer so tagging and discovery features share one persistence path.
 
-`GET /presets/{id}` is public. The controller delegates preset lookup to the service layer and returns the preset metadata, scene data, thumbnail reference, and creation timestamp when the preset exists.
+`GET /api/presets/{id}` is public. The controller delegates preset lookup to the service layer and returns the preset metadata, scene data, thumbnail reference, and creation timestamp when the preset exists.
 
-`DELETE /presets/{id}` runs behind authentication middleware. The middleware validates the bearer token, places the authenticated user in request context, and the controller delegates owner-only deletion rules to the service layer. The service rejects non-owner deletes with `403 Forbidden` and removes the preset through the shared persistence path, which also clears dependent preset/tag links through database cascading.
+`DELETE /api/presets/{id}` runs behind authentication middleware. The middleware validates the bearer token, places the authenticated user in request context, and the controller delegates owner-only deletion rules to the service layer. The service rejects non-owner deletes with `403 Forbidden` and removes the preset through the shared persistence path, which also clears dependent preset/tag links through database cascading.
 
-`GET /users/{id}/presets` runs behind authentication middleware. The middleware validates the bearer token, places the authenticated user in request context, and the controller delegates preset lookup for the requested user id to the service layer.
+`GET /api/users/{id}/presets` runs behind authentication middleware. The middleware validates the bearer token, places the authenticated user in request context, and the controller delegates preset lookup for the requested user id to the service layer.
 
 ### Service Layer
 
@@ -282,7 +282,7 @@ The codebase does not currently include:
 - logout or token revocation
 - token expiration
 
-Successful `POST /auth/login` and `POST /auth/google` requests issue bearer access tokens. Bearer-token authentication currently protects `GET /users/me`, `POST /presets`, `GET /presets`, `POST /presets/{id}/tags`, `DELETE /presets/{id}`, and `GET /users/{id}/presets`, while `GET /presets/{id}` remains public.
+Successful `POST /api/auth/login` and `POST /api/auth/google` requests issue bearer access tokens. Bearer-token authentication currently protects `GET /api/users/me`, `POST /api/presets`, `GET /api/presets`, `POST /api/presets/{id}/tags`, `DELETE /api/presets/{id}`, and `GET /api/users/{id}/presets`, while `GET /api/presets/{id}` remains public.
 
 ## Target Architecture as the Backend Grows
 
@@ -314,3 +314,5 @@ Responsibilities:
 - `exception`: custom exceptions and global error mapping
 - `client`: wrappers for external services
 - `job`: scheduled work, asynchronous tasks, background processing
+
+

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -68,99 +68,99 @@ Once the backend is running, open the following endpoints:
 
 - http://localhost:8080/health
 - http://localhost:8080/ready
-- POST http://localhost:8080/auth/register
-- POST http://localhost:8080/auth/login
-- POST http://localhost:8080/auth/google
-- POST http://localhost:8080/auth/link/google
-- POST http://localhost:8080/auth/link/local
-- GET http://localhost:8080/users/me
-- POST http://localhost:8080/tags
-- POST http://localhost:8080/presets
-- GET http://localhost:8080/presets
-- POST http://localhost:8080/presets/{presetId}/tags
-- GET http://localhost:8080/presets/{presetId}
-- DELETE http://localhost:8080/presets/{presetId}
-- GET http://localhost:8080/users/{id}/presets
+- POST http://localhost:8080/api/auth/register
+- POST http://localhost:8080/api/auth/login
+- POST http://localhost:8080/api/auth/google
+- POST http://localhost:8080/api/auth/link/google
+- POST http://localhost:8080/api/auth/link/local
+- GET http://localhost:8080/api/users/me
+- POST http://localhost:8080/api/tags
+- POST http://localhost:8080/api/presets
+- GET http://localhost:8080/api/presets
+- POST http://localhost:8080/api/presets/{presetId}/tags
+- GET http://localhost:8080/api/presets/{presetId}
+- DELETE http://localhost:8080/api/presets/{presetId}
+- GET http://localhost:8080/api/users/{id}/presets
 
 Expected responses:
 
 - `/health` returns `200 OK` with `{"status":"UP"}`
 - `/ready` returns `200 OK` with `{"status":"UP","database":"UP"}` when PostgreSQL is reachable
-- `POST /auth/register` returns `201 Created` for a new local account and never returns the raw password or stored password hash
-- `POST /auth/register` returns `409 Conflict` with `ACCOUNT_LINK_REQUIRED` when the email already belongs to a Google-backed account and local auth must be linked explicitly
-- `POST /auth/login` returns `200 OK` when a local account's credentials are valid and includes an `accessToken` for protected endpoints without exposing the raw password or stored password hash
-- `POST /auth/google` returns either `201 Created` or `200 OK` and includes an `accessToken` for protected endpoints
-- `POST /auth/google` returns `409 Conflict` with `ACCOUNT_LINK_REQUIRED` when a local-only account already exists for the verified email
-- `POST /auth/link/google` returns `200 OK` when both the local credentials and Google token prove ownership of the same email and the second provider is linked
-- `POST /auth/link/local` returns `200 OK` when a valid Google-backed account context is used to attach local password authentication
-- `GET /users/me` returns `200 OK` with the authenticated user's profile when the request includes `Authorization: Bearer <accessToken>`
-- `POST /tags` returns `201 Created` with the persisted normalized tag fields
-- `POST /presets` returns `201 Created` with the created preset fields when the request includes `Authorization: Bearer <accessToken>`
-- `GET /presets` returns `200 OK` with an array of presets when the request includes `Authorization: Bearer <accessToken>`, and `GET /presets?tag=ambient` returns only presets linked to that tag or an empty array when none match
-- `POST /presets/{presetId}/tags` returns `201 Created` with the preset/tag association fields when the request includes `Authorization: Bearer <accessToken>` and both records exist
-- `GET /presets/{presetId}` returns `200 OK` with the preset metadata, scene data, thumbnail reference, and creation timestamp when the preset exists, even without an `Authorization` header
-- `DELETE /presets/{presetId}` returns `204 No Content` when the request includes `Authorization: Bearer <accessToken>` and the authenticated user owns the preset, `403 Forbidden` when a different authenticated user tries to delete it, and `404 Not Found` when the preset does not exist
-- `GET /users/{id}/presets` returns `200 OK` with an array of presets for the requested user when the request includes `Authorization: Bearer <accessToken>`
+- `POST /api/auth/register` returns `201 Created` for a new local account and never returns the raw password or stored password hash
+- `POST /api/auth/register` returns `409 Conflict` with `ACCOUNT_LINK_REQUIRED` when the email already belongs to a Google-backed account and local auth must be linked explicitly
+- `POST /api/auth/login` returns `200 OK` when a local account's credentials are valid and includes an `accessToken` for protected endpoints without exposing the raw password or stored password hash
+- `POST /api/auth/google` returns either `201 Created` or `200 OK` and includes an `accessToken` for protected endpoints
+- `POST /api/auth/google` returns `409 Conflict` with `ACCOUNT_LINK_REQUIRED` when a local-only account already exists for the verified email
+- `POST /api/auth/link/google` returns `200 OK` when both the local credentials and Google token prove ownership of the same email and the second provider is linked
+- `POST /api/auth/link/local` returns `200 OK` when a valid Google-backed account context is used to attach local password authentication
+- `GET /api/users/me` returns `200 OK` with the authenticated user's profile when the request includes `Authorization: Bearer <accessToken>`
+- `POST /api/tags` returns `201 Created` with the persisted normalized tag fields
+- `POST /api/presets` returns `201 Created` with the created preset fields when the request includes `Authorization: Bearer <accessToken>`
+- `GET /api/presets` returns `200 OK` with an array of presets when the request includes `Authorization: Bearer <accessToken>`, and `GET /api/presets?tag=ambient` returns only presets linked to that tag or an empty array when none match
+- `POST /api/presets/{presetId}/tags` returns `201 Created` with the preset/tag association fields when the request includes `Authorization: Bearer <accessToken>` and both records exist
+- `GET /api/presets/{presetId}` returns `200 OK` with the preset metadata, scene data, thumbnail reference, and creation timestamp when the preset exists, even without an `Authorization` header
+- `DELETE /api/presets/{presetId}` returns `204 No Content` when the request includes `Authorization: Bearer <accessToken>` and the authenticated user owns the preset, `403 Forbidden` when a different authenticated user tries to delete it, and `404 Not Found` when the preset does not exist
+- `GET /api/users/{id}/presets` returns `200 OK` with an array of presets for the requested user when the request includes `Authorization: Bearer <accessToken>`
 
 If `/ready` returns `503`, the application process is running but not yet ready to serve traffic.
 
 To exercise the local registration endpoint:
 
-    curl -X POST http://localhost:8080/auth/register \
+    curl -X POST http://localhost:8080/api/auth/register \
       -H "Content-Type: application/json" \
       -d '{"email":"user@example.com","password":"example-password","displayName":"Example User"}'
 
 To exercise the local login endpoint:
 
-    curl -X POST http://localhost:8080/auth/login \
+    curl -X POST http://localhost:8080/api/auth/login \
       -H "Content-Type: application/json" \
       -d '{"email":"user@example.com","password":"example-password"}'
 
 Use the `accessToken` from the login response or Google auth response when calling protected endpoints.
 
-    curl -X POST http://localhost:8080/tags \
+    curl -X POST http://localhost:8080/api/tags \
       -H "Content-Type: application/json" \
       -d '{"name":"Ambient"}'
 
-    curl http://localhost:8080/users/me \
+    curl http://localhost:8080/api/users/me \
       -H "Authorization: Bearer <access-token>"
 
-    curl -X POST http://localhost:8080/presets \
+    curl -X POST http://localhost:8080/api/presets \
       -H "Authorization: Bearer <access-token>" \
       -H "Content-Type: application/json" \
       -d '{"name":"Aurora Drift","sceneData":{"visualizer":{"shader":"nebula"}},"thumbnailRef":"thumbnails/preset-1.png"}'
 
-    curl http://localhost:8080/presets?tag=ambient \
+    curl http://localhost:8080/api/presets?tag=ambient \
       -H "Authorization: Bearer <access-token>"
 
-    curl -X POST http://localhost:8080/presets/<preset-id>/tags \
+    curl -X POST http://localhost:8080/api/presets/<preset-id>/tags \
       -H "Authorization: Bearer <access-token>" \
       -H "Content-Type: application/json" \
       -d '{"tagId":<tag-id>}'
 
-    curl http://localhost:8080/presets/<preset-id>
+    curl http://localhost:8080/api/presets/<preset-id>
 
-    curl -X DELETE http://localhost:8080/presets/<preset-id> \
+    curl -X DELETE http://localhost:8080/api/presets/<preset-id> \
       -H "Authorization: Bearer <access-token>"
 
-    curl http://localhost:8080/users/<user-id>/presets \
+    curl http://localhost:8080/api/users/<user-id>/presets \
       -H "Authorization: Bearer <access-token>"
 
 To exercise the Google auth endpoint, send a Google ID token issued for one of the configured client IDs:
 
-    curl -X POST http://localhost:8080/auth/google \
+    curl -X POST http://localhost:8080/api/auth/google \
       -H "Content-Type: application/json" \
       -d '{"idToken":"<google-id-token>"}'
 
 To explicitly link Google to an existing local account, provide local credentials plus a valid Google ID token for the same email address:
 
-    curl -X POST http://localhost:8080/auth/link/google \
+    curl -X POST http://localhost:8080/api/auth/link/google \
       -H "Content-Type: application/json" \
       -d '{"email":"user@example.com","password":"example-password","idToken":"<google-id-token>"}'
 
 To add local email-and-password authentication to an existing Google-backed account, provide the Google ID token plus the new local password:
 
-    curl -X POST http://localhost:8080/auth/link/local \
+    curl -X POST http://localhost:8080/api/auth/link/local \
       -H "Content-Type: application/json" \
       -d '{"idToken":"<google-id-token>","password":"example-password"}'
 
@@ -247,19 +247,19 @@ If you are new to the repository, this sequence builds the fastest mental model 
 5. read `architecture.md`
 6. read `engineering-standards.md`
 7. trace the `/ready` endpoint from controller to service to datasource
-8. trace `POST /auth/register` from controller to service to repository and password hashing
-9. trace `POST /auth/login` from controller to service to repository and password hashing
-10. trace `POST /auth/google` from controller to service to verifier to repository
-11. trace `POST /auth/link/google` through the explicit local-credentials-plus-Google-token ownership checks
-12. trace `POST /auth/link/local` through the verified Google account context and password-link path
-13. trace `GET /users/me` from authentication middleware to controller to service to repository
-14. trace `POST /tags` from controller to service to repository
-15. trace `POST /presets` from authentication middleware to controller to service to repository
-16. trace `GET /presets` from authentication middleware to controller to service to repository, including the optional `tag` query parameter path
-17. trace `POST /presets/{id}/tags` from authentication middleware to controller to service to repository
-18. trace public `GET /presets/{id}` from the controller to the service to the repository
-19. trace `DELETE /presets/{id}` from authentication middleware to controller to service, including the owner-only authorization check
-20. trace `GET /users/{id}/presets` from authentication middleware to controller to service to repository
+8. trace `POST /api/auth/register` from controller to service to repository and password hashing
+9. trace `POST /api/auth/login` from controller to service to repository and password hashing
+10. trace `POST /api/auth/google` from controller to service to verifier to repository
+11. trace `POST /api/auth/link/google` through the explicit local-credentials-plus-Google-token ownership checks
+12. trace `POST /api/auth/link/local` through the verified Google account context and password-link path
+13. trace `GET /api/users/me` from authentication middleware to controller to service to repository
+14. trace `POST /api/tags` from controller to service to repository
+15. trace `POST /api/presets` from authentication middleware to controller to service to repository
+16. trace `GET /api/presets` from authentication middleware to controller to service to repository, including the optional `tag` query parameter path
+17. trace `POST /api/presets/{id}/tags` from authentication middleware to controller to service to repository
+18. trace public `GET /api/presets/{id}` from the controller to the service to the repository
+19. trace `DELETE /api/presets/{id}` from authentication middleware to controller to service, including the owner-only authorization check
+20. trace `GET /api/users/{id}/presets` from authentication middleware to controller to service to repository
 
 ## Expected Change Workflow
 
@@ -273,3 +273,5 @@ When making backend changes, follow this order:
 6. update documentation if developer or operational workflows change
 
 Also check out: [architecture.md](architecture.md), [engineering-standards.md](engineering-standards.md), and [operations.md](operations.md)
+
+

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -20,9 +20,9 @@ Operationally important behavior:
 - Flyway applies migrations automatically on startup
 - local passwords are hashed and verified with BCrypt through the shared password hashing service
 - Google ID tokens are verified server-side against `MAGE_AUTH_GOOGLE_CLIENT_IDS`
-- successful `POST /auth/login` and `POST /auth/google` requests issue bearer access tokens
+- successful `POST /api/auth/login` and `POST /api/auth/google` requests issue bearer access tokens
 - local and Google auth providers can be linked explicitly, but never auto-linked only because emails match
-- authentication middleware validates bearer tokens for protected `/users/**` endpoints and protected preset routes, while `GET /presets/{id}` remains public
+- authentication middleware validates bearer tokens for protected `/api/users/**` endpoints and protected preset routes, while `GET /api/presets/{id}` remains public
 
 ## Local Startup Runbook
 
@@ -35,7 +35,7 @@ Use this when:
 - validating Docker-based local behavior
 - testing migration behavior against a clean containerized stack
 
-Before using `POST /auth/google`, replace the placeholder value in `.env` for `MAGE_AUTH_GOOGLE_CLIENT_IDS` with the Google OAuth client ID used by the frontend.
+Before using `POST /api/auth/google`, replace the placeholder value in `.env` for `MAGE_AUTH_GOOGLE_CLIENT_IDS` with the Google OAuth client ID used by the frontend.
 
 ## Health Checks and Auth Endpoints
 
@@ -43,19 +43,19 @@ The backend currently exposes fifteen operational endpoints:
 
 - `GET /health`
 - `GET /ready`
-- `POST /auth/register`
-- `POST /auth/login`
-- `POST /auth/google`
-- `POST /auth/link/google`
-- `POST /auth/link/local`
-- `GET /users/me`
-- `POST /tags`
-- `POST /presets`
-- `GET /presets`
-- `POST /presets/{id}/tags`
-- `GET /presets/{id}`
-- `DELETE /presets/{id}`
-- `GET /users/{id}/presets`
+- `POST /api/auth/register`
+- `POST /api/auth/login`
+- `POST /api/auth/google`
+- `POST /api/auth/link/google`
+- `POST /api/auth/link/local`
+- `GET /api/users/me`
+- `POST /api/tags`
+- `POST /api/presets`
+- `GET /api/presets`
+- `POST /api/presets/{id}/tags`
+- `GET /api/presets/{id}`
+- `DELETE /api/presets/{id}`
+- `GET /api/users/{id}/presets`
 
 ### `/health`
 
@@ -95,7 +95,7 @@ Expected not-ready behavior:
 - HTTP `503 Service Unavailable`
 - response body shows the application and database status
 
-### `POST /auth/register`
+### `POST /api/auth/register`
 
 Purpose:
 
@@ -123,7 +123,7 @@ Failure behavior:
 - HTTP `409 Conflict` with `EMAIL_ALREADY_REGISTERED` when local authentication is already configured for that email
 - HTTP `409 Conflict` with `ACCOUNT_LINK_REQUIRED` when the email belongs to a Google-backed account and explicit linking is required
 
-### `POST /auth/login`
+### `POST /api/auth/login`
 
 Purpose:
 
@@ -149,7 +149,7 @@ Failure behavior:
 - HTTP `400 Bad Request` for malformed JSON or request validation failures
 - HTTP `401 Unauthorized` when the credentials do not match a local account
 
-### `POST /auth/google`
+### `POST /api/auth/google`
 
 Purpose:
 
@@ -176,7 +176,7 @@ Failure behavior:
 - HTTP `409 Conflict` with `ACCOUNT_LINK_REQUIRED` when a local-only account already exists for the verified email
 - HTTP `409 Conflict` with `ACCOUNT_CONFLICT` when a different Google identity already owns that email in the backend
 
-### `POST /auth/link/google`
+### `POST /api/auth/link/google`
 
 Purpose:
 
@@ -204,7 +204,7 @@ Failure behavior:
 - HTTP `401 Unauthorized` with `INVALID_LOCAL_CREDENTIALS` when the supplied local email/password pair is invalid
 - HTTP `409 Conflict` with `ACCOUNT_CONFLICT` when the Google token email does not match the local email or the Google identity already belongs to another account
 
-### `POST /auth/link/local`
+### `POST /api/auth/link/local`
 
 Purpose:
 
@@ -232,7 +232,7 @@ Failure behavior:
 - HTTP `409 Conflict` with `ACCOUNT_LINK_REQUIRED` when no Google-backed account exists yet for that Google identity
 - HTTP `409 Conflict` with `ACCOUNT_CONFLICT` when the link request collides with an incompatible existing account state
 
-### `GET /users/me`
+### `GET /api/users/me`
 
 Purpose:
 
@@ -240,7 +240,7 @@ Purpose:
 
 Request notes:
 
-- requires an `Authorization: Bearer <accessToken>` header using a token issued by `POST /auth/login` or `POST /auth/google`
+- requires an `Authorization: Bearer <accessToken>` header using a token issued by `POST /api/auth/login` or `POST /api/auth/google`
 
 Success behavior:
 
@@ -252,7 +252,7 @@ Failure behavior:
 
 - HTTP `401 Unauthorized` when the request is missing a bearer token, uses an invalid token, or the token points to a user record that no longer exists
 
-### `POST /tags`
+### `POST /api/tags`
 
 Purpose:
 
@@ -276,7 +276,7 @@ Failure behavior:
 - HTTP `400 Bad Request` for malformed JSON or request validation failures
 - HTTP `409 Conflict` when the supplied tag name already exists after normalization
 
-### `POST /presets`
+### `POST /api/presets`
 
 Purpose:
 
@@ -284,7 +284,7 @@ Purpose:
 
 Request notes:
 
-- requires an `Authorization: Bearer <accessToken>` header using a token issued by `POST /auth/login` or `POST /auth/google`
+- requires an `Authorization: Bearer <accessToken>` header using a token issued by `POST /api/auth/login` or `POST /api/auth/google`
 
 Request:
 
@@ -310,7 +310,7 @@ Failure behavior:
 - HTTP `400 Bad Request` for malformed JSON or request validation failures
 - HTTP `401 Unauthorized` when the request is missing a bearer token, uses an invalid token, or the token points to a user record that no longer exists
 
-### `GET /presets`
+### `GET /api/presets`
 
 Purpose:
 
@@ -319,7 +319,7 @@ Purpose:
 
 Request notes:
 
-- requires an `Authorization: Bearer <accessToken>` header using a token issued by `POST /auth/login` or `POST /auth/google`
+- requires an `Authorization: Bearer <accessToken>` header using a token issued by `POST /api/auth/login` or `POST /api/auth/google`
 - when `tag` is omitted, the endpoint returns all persisted presets
 - when `tag` is provided, the backend trims and normalizes it before looking up linked presets
 
@@ -327,14 +327,14 @@ Success behavior:
 
 - HTTP `200 OK` for a valid authenticated request
 - response includes an array of preset records
-- `GET /presets?tag=ambient` returns only presets linked to that tag
+- `GET /api/presets?tag=ambient` returns only presets linked to that tag
 - returns an empty array when no presets match the supplied tag
 
 Failure behavior:
 
 - HTTP `401 Unauthorized` when the request is missing a bearer token, uses an invalid token, or the token points to a user record that no longer exists
 
-### `POST /presets/{id}/tags`
+### `POST /api/presets/{id}/tags`
 
 Purpose:
 
@@ -342,7 +342,7 @@ Purpose:
 
 Request notes:
 
-- requires an `Authorization: Bearer <accessToken>` header using a token issued by `POST /auth/login` or `POST /auth/google`
+- requires an `Authorization: Bearer <accessToken>` header using a token issued by `POST /api/auth/login` or `POST /api/auth/google`
 
 Request:
 
@@ -364,7 +364,7 @@ Failure behavior:
 - HTTP `404 Not Found` when either the preset or tag does not exist
 - HTTP `409 Conflict` when the preset already has that tag attached
 
-### `GET /presets/{id}`
+### `GET /api/presets/{id}`
 
 Purpose:
 
@@ -384,7 +384,7 @@ Failure behavior:
 
 - HTTP `404 Not Found` when no preset exists for the supplied id
 
-### `DELETE /presets/{id}`
+### `DELETE /api/presets/{id}`
 
 Purpose:
 
@@ -392,7 +392,7 @@ Purpose:
 
 Request notes:
 
-- requires an `Authorization: Bearer <accessToken>` header using a token issued by `POST /auth/login` or `POST /auth/google`
+- requires an `Authorization: Bearer <accessToken>` header using a token issued by `POST /api/auth/login` or `POST /api/auth/google`
 
 Success behavior:
 
@@ -405,7 +405,7 @@ Failure behavior:
 - HTTP `403 Forbidden` when the request is authenticated successfully but the preset belongs to a different user
 - HTTP `404 Not Found` when no preset exists for the supplied id
 
-### `GET /users/{id}/presets`
+### `GET /api/users/{id}/presets`
 
 Purpose:
 
@@ -413,7 +413,7 @@ Purpose:
 
 Request notes:
 
-- requires an `Authorization: Bearer <accessToken>` header using a token issued by `POST /auth/login` or `POST /auth/google`
+- requires an `Authorization: Bearer <accessToken>` header using a token issued by `POST /api/auth/login` or `POST /api/auth/google`
 
 Success behavior:
 
@@ -434,19 +434,19 @@ After startup, verify these items in order:
 3. backend logs show Flyway applying or validating migrations
 4. `curl http://localhost:8080/health` returns `200`
 5. `curl http://localhost:8080/ready` returns `200`
-6. `POST /auth/register` succeeds for a new local email address
-7. `POST /auth/login` succeeds for that local account and returns an `accessToken`
-8. `GET /users/me` succeeds when called with `Authorization: Bearer <accessToken>`
-9. `POST /auth/google` succeeds with a valid Google ID token issued for a configured client ID and returns an `accessToken`
-10. `POST /auth/link/google` succeeds when both the local credentials and Google token prove ownership of the same email
-11. `POST /auth/link/local` succeeds for an existing Google-backed account with a valid Google ID token
-12. `POST /tags` succeeds with a valid tag payload and returns the normalized tag record
-13. `POST /presets` succeeds when called with `Authorization: Bearer <accessToken>` and a valid preset payload
-14. `GET /presets` succeeds when called with `Authorization: Bearer <accessToken>` and returns either all presets, only presets matching `?tag=<name>`, or an empty array when no presets match
-15. `POST /presets/{id}/tags` succeeds when called with `Authorization: Bearer <accessToken>`, an existing preset id, and an existing tag id
-16. `GET /presets/{id}` succeeds for public requests and returns the preset when the id exists
-17. `DELETE /presets/{id}` succeeds when called with `Authorization: Bearer <accessToken>` by the preset owner and returns `204 No Content`
-18. `GET /users/{id}/presets` succeeds when called with `Authorization: Bearer <accessToken>` and returns either preset records or an empty array
+6. `POST /api/auth/register` succeeds for a new local email address
+7. `POST /api/auth/login` succeeds for that local account and returns an `accessToken`
+8. `GET /api/users/me` succeeds when called with `Authorization: Bearer <accessToken>`
+9. `POST /api/auth/google` succeeds with a valid Google ID token issued for a configured client ID and returns an `accessToken`
+10. `POST /api/auth/link/google` succeeds when both the local credentials and Google token prove ownership of the same email
+11. `POST /api/auth/link/local` succeeds for an existing Google-backed account with a valid Google ID token
+12. `POST /api/tags` succeeds with a valid tag payload and returns the normalized tag record
+13. `POST /api/presets` succeeds when called with `Authorization: Bearer <accessToken>` and a valid preset payload
+14. `GET /api/presets` succeeds when called with `Authorization: Bearer <accessToken>` and returns either all presets, only presets matching `?tag=<name>`, or an empty array when no presets match
+15. `POST /api/presets/{id}/tags` succeeds when called with `Authorization: Bearer <accessToken>`, an existing preset id, and an existing tag id
+16. `GET /api/presets/{id}` succeeds for public requests and returns the preset when the id exists
+17. `DELETE /api/presets/{id}` succeeds when called with `Authorization: Bearer <accessToken>` by the preset owner and returns `204 No Content`
+18. `GET /api/users/{id}/presets` succeeds when called with `Authorization: Bearer <accessToken>` and returns either preset records or an empty array
 
 If step 5 fails with `503`, the app is running but not ready to serve traffic.
 
@@ -546,7 +546,7 @@ Check:
 - PostgreSQL container health
 - datasource environment variables
 
-### `POST /auth/google` returns `401`
+### `POST /api/auth/google` returns `401`
 
 Interpretation:
 
@@ -558,113 +558,113 @@ Check:
 - the token was issued for a client ID listed in `MAGE_AUTH_GOOGLE_CLIENT_IDS`
 - the token has not expired
 
-### `POST /auth/google` returns `409`
+### `POST /api/auth/google` returns `409`
 
 Interpretation:
 
-- either a local-only account already owns that email and `/auth/link/google` must be used
+- either a local-only account already owns that email and `/api/auth/link/google` must be used
 - or a different Google identity already owns that email in the backend
 
-### `POST /auth/register` returns `409`
+### `POST /api/auth/register` returns `409`
 
 Interpretation:
 
 - either local authentication is already configured for that email
-- or the email belongs to a Google-backed account and `/auth/link/local` must be used instead
+- or the email belongs to a Google-backed account and `/api/auth/link/local` must be used instead
 
-### `POST /auth/login` returns `401`
+### `POST /api/auth/login` returns `401`
 
 Interpretation:
 
 - the supplied credentials did not match an account with local authentication
 
-### `POST /auth/link/google` returns `401`
+### `POST /api/auth/link/google` returns `401`
 
 Interpretation:
 
 - the supplied local email/password pair did not pass the ownership check
 
-### `POST /auth/link/google` returns `409`
+### `POST /api/auth/link/google` returns `409`
 
 Interpretation:
 
 - the Google token email does not match the local account email
 - or the Google identity is already linked to a different account
 
-### `POST /auth/link/local` returns `409`
+### `POST /api/auth/link/local` returns `409`
 
 Interpretation:
 
-- the Google-backed account has not been provisioned yet through `POST /auth/google`
+- the Google-backed account has not been provisioned yet through `POST /api/auth/google`
 - or the request conflicts with an incompatible existing account state
 
-### `GET /users/me` returns `401`
+### `GET /api/users/me` returns `401`
 
 Interpretation:
 
 - the request was missing a bearer token, the token was invalid, or the token points to a user record that no longer exists
 
-### `POST /tags` returns `409`
+### `POST /api/tags` returns `409`
 
 Interpretation:
 
 - the supplied tag name already exists after normalization, so the backend rejects the duplicate tag creation request
 
-### `POST /presets` returns `401`
+### `POST /api/presets` returns `401`
 
 Interpretation:
 
 - the request was missing a bearer token, the token was invalid, or the token points to a user record that no longer exists
 
-### `POST /presets/{id}/tags` returns `401`
+### `POST /api/presets/{id}/tags` returns `401`
 
 Interpretation:
 
 - the request was missing a bearer token, the token was invalid, or the token points to a user record that no longer exists
 
-### `GET /presets` returns `401`
+### `GET /api/presets` returns `401`
 
 Interpretation:
 
 - the request was missing a bearer token, the token was invalid, or the token points to a user record that no longer exists
 
-### `DELETE /presets/{id}` returns `401`
+### `DELETE /api/presets/{id}` returns `401`
 
 Interpretation:
 
 - the request was missing a bearer token, the token was invalid, or the token points to a user record that no longer exists
 
-### `GET /users/{id}/presets` returns `401`
+### `GET /api/users/{id}/presets` returns `401`
 
 Interpretation:
 
 - the request was missing a bearer token, the token was invalid, or the token points to a user record that no longer exists
 
-### `GET /presets/{id}` returns `404`
+### `GET /api/presets/{id}` returns `404`
 
 Interpretation:
 
 - no preset exists for that id, regardless of whether the caller is signed in
 
-### `DELETE /presets/{id}` returns `403`
+### `DELETE /api/presets/{id}` returns `403`
 
 Interpretation:
 
 - the request was authenticated successfully, but the preset belongs to a different user
 
-### `DELETE /presets/{id}` returns `404`
+### `DELETE /api/presets/{id}` returns `404`
 
 Interpretation:
 
 - the request was authenticated successfully, but no preset exists for that id
 
-### `POST /presets/{id}/tags` returns `404`
+### `POST /api/presets/{id}/tags` returns `404`
 
 Interpretation:
 
 - the request was authenticated successfully, but either the preset id or tag id did not match an existing record
 
-### `POST /presets/{id}/tags` returns `409`
+### `POST /api/presets/{id}/tags` returns `409`
 
 Interpretation:
 
@@ -701,3 +701,5 @@ macOS/Linux:
 ```bash
 ./mvnw test
 ```
+
+

--- a/docs/tag-filter-testing/README.md
+++ b/docs/tag-filter-testing/README.md
@@ -10,7 +10,7 @@ If Docker Compose is not installed yet, first follow [Install Docker Compose](..
 
 Verify that:
 
-- `GET /presets?tag=ambient` returns only presets linked to the `ambient` tag
+- `GET /api/presets?tag=ambient` returns only presets linked to the `ambient` tag
 - tag filtering is case-insensitive and whitespace-tolerant
 - the endpoint returns `[]` when no presets match
 
@@ -51,7 +51,7 @@ Use the second terminal for the API requests below.
 
 ```powershell
 $register = Invoke-RestMethod -Method Post `
-  -Uri "http://localhost:8080/auth/register" `
+  -Uri "http://localhost:8080/api/auth/register" `
   -ContentType "application/json" `
   -Body '{"email":"filter-test@example.com","password":"test-password","displayName":"Filter Test User"}'
 ```
@@ -60,7 +60,7 @@ $register = Invoke-RestMethod -Method Post `
 
 ```powershell
 $login = Invoke-RestMethod -Method Post `
-  -Uri "http://localhost:8080/auth/login" `
+  -Uri "http://localhost:8080/api/auth/login" `
   -ContentType "application/json" `
   -Body '{"email":"filter-test@example.com","password":"test-password"}'
 
@@ -71,12 +71,12 @@ $token = $login.accessToken
 
 ```powershell
 $ambientTag = Invoke-RestMethod -Method Post `
-  -Uri "http://localhost:8080/tags" `
+  -Uri "http://localhost:8080/api/tags" `
   -ContentType "application/json" `
   -Body '{"name":"ambient"}'
 
 $showcaseTag = Invoke-RestMethod -Method Post `
-  -Uri "http://localhost:8080/tags" `
+  -Uri "http://localhost:8080/api/tags" `
   -ContentType "application/json" `
   -Body '{"name":"showcase"}'
 ```
@@ -85,13 +85,13 @@ $showcaseTag = Invoke-RestMethod -Method Post `
 
 ```powershell
 $preset1 = Invoke-RestMethod -Method Post `
-  -Uri "http://localhost:8080/presets" `
+  -Uri "http://localhost:8080/api/presets" `
   -Headers @{ Authorization = "Bearer $token" } `
   -ContentType "application/json" `
   -Body '{"name":"Aurora Drift","sceneData":{"visualizer":{"shader":"nebula"}}}'
 
 $preset2 = Invoke-RestMethod -Method Post `
-  -Uri "http://localhost:8080/presets" `
+  -Uri "http://localhost:8080/api/presets" `
   -Headers @{ Authorization = "Bearer $token" } `
   -ContentType "application/json" `
   -Body '{"name":"Signal Bloom","sceneData":{"visualizer":{"shader":"pulse"}}}'
@@ -101,13 +101,13 @@ $preset2 = Invoke-RestMethod -Method Post `
 
 ```powershell
 Invoke-RestMethod -Method Post `
-  -Uri "http://localhost:8080/presets/$($preset1.presetId)/tags" `
+  -Uri "http://localhost:8080/api/presets/$($preset1.presetId)/tags" `
   -Headers @{ Authorization = "Bearer $token" } `
   -ContentType "application/json" `
   -Body "{""tagId"":$($ambientTag.tagId)}"
 
 Invoke-RestMethod -Method Post `
-  -Uri "http://localhost:8080/presets/$($preset2.presetId)/tags" `
+  -Uri "http://localhost:8080/api/presets/$($preset2.presetId)/tags" `
   -Headers @{ Authorization = "Bearer $token" } `
   -ContentType "application/json" `
   -Body "{""tagId"":$($showcaseTag.tagId)}"
@@ -117,7 +117,7 @@ Invoke-RestMethod -Method Post `
 
 ```powershell
 Invoke-RestMethod -Method Get `
-  -Uri "http://localhost:8080/presets?tag=ambient" `
+  -Uri "http://localhost:8080/api/presets?tag=ambient" `
   -Headers @{ Authorization = "Bearer $token" }
 ```
 
@@ -129,7 +129,7 @@ Expected result:
 
 ```powershell
 Invoke-RestMethod -Method Get `
-  -Uri "http://localhost:8080/presets?tag=%20AMBIENT%20" `
+  -Uri "http://localhost:8080/api/presets?tag=%20AMBIENT%20" `
   -Headers @{ Authorization = "Bearer $token" }
 ```
 
@@ -141,7 +141,7 @@ Expected result:
 
 ```powershell
 Invoke-RestMethod -Method Get `
-  -Uri "http://localhost:8080/presets?tag=does-not-exist" `
+  -Uri "http://localhost:8080/api/presets?tag=does-not-exist" `
   -Headers @{ Authorization = "Bearer $token" }
 ```
 
@@ -153,7 +153,7 @@ Expected result:
 
 ```powershell
 Invoke-RestMethod -Method Get `
-  -Uri "http://localhost:8080/presets" `
+  -Uri "http://localhost:8080/api/presets" `
   -Headers @{ Authorization = "Bearer $token" }
 ```
 
@@ -174,3 +174,5 @@ To remove containers afterward:
 ```powershell
 docker compose down
 ```
+
+

--- a/src/main/java/com/bdmage/mage_backend/config/AuthenticationConfiguration.java
+++ b/src/main/java/com/bdmage/mage_backend/config/AuthenticationConfiguration.java
@@ -16,6 +16,6 @@ public class AuthenticationConfiguration implements WebMvcConfigurer {
 	@Override
 	public void addInterceptors(InterceptorRegistry registry) {
 		registry.addInterceptor(this.authenticationInterceptor)
-				.addPathPatterns("/users/**", "/presets/**");
+				.addPathPatterns("/users/**", "/api/users/**", "/presets/**", "/api/presets/**");
 	}
 }

--- a/src/main/java/com/bdmage/mage_backend/config/AuthenticationConfiguration.java
+++ b/src/main/java/com/bdmage/mage_backend/config/AuthenticationConfiguration.java
@@ -16,6 +16,6 @@ public class AuthenticationConfiguration implements WebMvcConfigurer {
 	@Override
 	public void addInterceptors(InterceptorRegistry registry) {
 		registry.addInterceptor(this.authenticationInterceptor)
-				.addPathPatterns("/users/**", "/api/users/**", "/presets/**", "/api/presets/**");
+				.addPathPatterns("/api/users/**", "/api/presets/**");
 	}
 }

--- a/src/main/java/com/bdmage/mage_backend/config/AuthenticationInterceptor.java
+++ b/src/main/java/com/bdmage/mage_backend/config/AuthenticationInterceptor.java
@@ -1,7 +1,5 @@
 package com.bdmage.mage_backend.config;
 
-import java.util.List;
-
 import com.bdmage.mage_backend.exception.AuthenticationRequiredException;
 import com.bdmage.mage_backend.model.User;
 import com.bdmage.mage_backend.service.AuthenticationTokenService;
@@ -19,9 +17,7 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
 
 	private static final String AUTHENTICATION_REQUIRED_MESSAGE = "Authentication is required.";
 	private static final String BEARER_PREFIX = "Bearer ";
-	private static final List<String> PUBLIC_PRESET_DETAIL_PATTERNS = List.of(
-			"/presets/{id}",
-			"/api/presets/{id}");
+	private static final String PUBLIC_PRESET_DETAIL_PATTERN = "/api/presets/{id}";
 	private static final AntPathMatcher PATH_MATCHER = new AntPathMatcher();
 
 	private final AuthenticationTokenService authenticationTokenService;
@@ -46,8 +42,7 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
 
 	private static boolean isPublicPresetDetailRequest(HttpServletRequest request) {
 		return HttpMethod.GET.matches(request.getMethod())
-				&& PUBLIC_PRESET_DETAIL_PATTERNS.stream()
-						.anyMatch(pattern -> PATH_MATCHER.match(pattern, pathWithinApplication(request)));
+				&& PATH_MATCHER.match(PUBLIC_PRESET_DETAIL_PATTERN, pathWithinApplication(request));
 	}
 
 	private static String pathWithinApplication(HttpServletRequest request) {

--- a/src/main/java/com/bdmage/mage_backend/config/AuthenticationInterceptor.java
+++ b/src/main/java/com/bdmage/mage_backend/config/AuthenticationInterceptor.java
@@ -1,5 +1,7 @@
 package com.bdmage.mage_backend.config;
 
+import java.util.List;
+
 import com.bdmage.mage_backend.exception.AuthenticationRequiredException;
 import com.bdmage.mage_backend.model.User;
 import com.bdmage.mage_backend.service.AuthenticationTokenService;
@@ -17,7 +19,9 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
 
 	private static final String AUTHENTICATION_REQUIRED_MESSAGE = "Authentication is required.";
 	private static final String BEARER_PREFIX = "Bearer ";
-	private static final String PUBLIC_PRESET_DETAIL_PATTERN = "/presets/{id}";
+	private static final List<String> PUBLIC_PRESET_DETAIL_PATTERNS = List.of(
+			"/presets/{id}",
+			"/api/presets/{id}");
 	private static final AntPathMatcher PATH_MATCHER = new AntPathMatcher();
 
 	private final AuthenticationTokenService authenticationTokenService;
@@ -28,7 +32,7 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
 
 	@Override
 	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
-		// Public preset detail pages allow anonymous GET /presets/{id} reads without
+		// Public preset detail pages allow anonymous GET /api/presets/{id} reads without
 		// opening write or owner-sensitive preset routes.
 		if (isPublicPresetDetailRequest(request)) {
 			return true;
@@ -42,7 +46,8 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
 
 	private static boolean isPublicPresetDetailRequest(HttpServletRequest request) {
 		return HttpMethod.GET.matches(request.getMethod())
-				&& PATH_MATCHER.match(PUBLIC_PRESET_DETAIL_PATTERN, pathWithinApplication(request));
+				&& PUBLIC_PRESET_DETAIL_PATTERNS.stream()
+						.anyMatch(pattern -> PATH_MATCHER.match(pattern, pathWithinApplication(request)));
 	}
 
 	private static String pathWithinApplication(HttpServletRequest request) {

--- a/src/main/java/com/bdmage/mage_backend/controller/AuthController.java
+++ b/src/main/java/com/bdmage/mage_backend/controller/AuthController.java
@@ -26,7 +26,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/auth")
+@RequestMapping({"/auth", "/api/auth"})
 public class AuthController {
 
 	private final AccountLinkingService accountLinkingService;

--- a/src/main/java/com/bdmage/mage_backend/controller/AuthController.java
+++ b/src/main/java/com/bdmage/mage_backend/controller/AuthController.java
@@ -26,7 +26,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping({"/auth", "/api/auth"})
+@RequestMapping("/api/auth")
 public class AuthController {
 
 	private final AccountLinkingService accountLinkingService;

--- a/src/main/java/com/bdmage/mage_backend/controller/PresetController.java
+++ b/src/main/java/com/bdmage/mage_backend/controller/PresetController.java
@@ -27,7 +27,7 @@ import com.bdmage.mage_backend.service.PresetService;
 import jakarta.validation.Valid;
 
 @RestController
-@RequestMapping({"/presets", "/api/presets"})
+@RequestMapping("/api/presets")
 public class PresetController {
 
 	private final PresetService presetService;

--- a/src/main/java/com/bdmage/mage_backend/controller/PresetController.java
+++ b/src/main/java/com/bdmage/mage_backend/controller/PresetController.java
@@ -27,7 +27,7 @@ import com.bdmage.mage_backend.service.PresetService;
 import jakarta.validation.Valid;
 
 @RestController
-@RequestMapping("/presets")
+@RequestMapping({"/presets", "/api/presets"})
 public class PresetController {
 
 	private final PresetService presetService;

--- a/src/main/java/com/bdmage/mage_backend/controller/TagController.java
+++ b/src/main/java/com/bdmage/mage_backend/controller/TagController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/tags")
+@RequestMapping({"/tags", "/api/tags"})
 public class TagController {
 
 	private final TagService tagService;

--- a/src/main/java/com/bdmage/mage_backend/controller/TagController.java
+++ b/src/main/java/com/bdmage/mage_backend/controller/TagController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping({"/tags", "/api/tags"})
+@RequestMapping("/api/tags")
 public class TagController {
 
 	private final TagService tagService;

--- a/src/main/java/com/bdmage/mage_backend/controller/UserController.java
+++ b/src/main/java/com/bdmage/mage_backend/controller/UserController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping({"/users", "/api/users"})
+@RequestMapping("/api/users")
 public class UserController {
 
 	private final PresetService presetService;

--- a/src/main/java/com/bdmage/mage_backend/controller/UserController.java
+++ b/src/main/java/com/bdmage/mage_backend/controller/UserController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/users")
+@RequestMapping({"/users", "/api/users"})
 public class UserController {
 
 	private final PresetService presetService;

--- a/src/main/java/com/bdmage/mage_backend/service/AccountLinkingService.java
+++ b/src/main/java/com/bdmage/mage_backend/service/AccountLinkingService.java
@@ -80,7 +80,7 @@ public class AccountLinkingService {
 				User user = existingUser.get();
 				if (user.supportsLocalAuthentication() && !user.supportsGoogleAuthentication()) {
 					throw new AccountLinkRequiredException(
-							"A local account already exists for this email. Link Google through /auth/link/google after authenticating that local account.");
+							"A local account already exists for this email. Link Google through /api/auth/link/google after authenticating that local account.");
 				}
 				if (user.supportsGoogleAuthentication()) {
 					throw new AccountConflictException(
@@ -89,7 +89,7 @@ public class AccountLinkingService {
 			}
 
 			throw new AccountLinkRequiredException(
-					"Authenticate with Google through /auth/google before linking local authentication.");
+					"Authenticate with Google through /api/auth/google before linking local authentication.");
 		}
 
 		User user = googleUser.get();
@@ -141,3 +141,4 @@ public class AccountLinkingService {
 	public record AccountLinkingResult(User user, boolean linked) {
 	}
 }
+

--- a/src/main/java/com/bdmage/mage_backend/service/GoogleAuthenticationService.java
+++ b/src/main/java/com/bdmage/mage_backend/service/GoogleAuthenticationService.java
@@ -47,7 +47,7 @@ public class GoogleAuthenticationService {
 			}
 
 			throw new AccountLinkRequiredException(
-					"A local account already exists for this email. Link Google through /auth/link/google after authenticating that local account.");
+					"A local account already exists for this email. Link Google through /api/auth/link/google after authenticating that local account.");
 		}
 
 		User googleUser = User.google(
@@ -72,7 +72,7 @@ public class GoogleAuthenticationService {
 				}
 
 				throw new AccountLinkRequiredException(
-						"A local account already exists for this email. Link Google through /auth/link/google after authenticating that local account.");
+						"A local account already exists for this email. Link Google through /api/auth/link/google after authenticating that local account.");
 			}
 
 			throw new AccountConflictException("Google authentication conflicted with an existing account.");
@@ -108,3 +108,4 @@ public class GoogleAuthenticationService {
 	public record GoogleAuthenticationResult(User user, boolean created) {
 	}
 }
+

--- a/src/main/java/com/bdmage/mage_backend/service/RegistrationService.java
+++ b/src/main/java/com/bdmage/mage_backend/service/RegistrationService.java
@@ -35,7 +35,7 @@ public class RegistrationService {
 			}
 
 			throw new AccountLinkRequiredException(
-					"A Google-backed account already exists for this email. Link local authentication through /auth/link/local after authenticating with Google.");
+					"A Google-backed account already exists for this email. Link local authentication through /api/auth/link/local after authenticating with Google.");
 		}
 
 		String passwordHash = this.passwordHashingService.hash(plainPassword);
@@ -43,3 +43,4 @@ public class RegistrationService {
 		return this.userRepository.saveAndFlush(newUser);
 	}
 }
+

--- a/src/test/java/com/bdmage/mage_backend/config/AuthenticationInterceptorTests.java
+++ b/src/test/java/com/bdmage/mage_backend/config/AuthenticationInterceptorTests.java
@@ -50,10 +50,10 @@ class AuthenticationInterceptorTests {
 	}
 
 	@Test
-	void preHandleAllowsPublicPresetDetailRequestWithoutAuthenticationHeader() {
+	void preHandleAllowsPublicApiPresetDetailRequestWithoutAuthenticationHeader() {
 		AuthenticationTokenService authenticationTokenService = mock(AuthenticationTokenService.class);
 		AuthenticationInterceptor interceptor = new AuthenticationInterceptor(authenticationTokenService);
-		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/presets/15");
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/presets/15");
 		MockHttpServletResponse response = new MockHttpServletResponse();
 
 		assertThat(interceptor.preHandle(request, response, new Object())).isTrue();
@@ -63,10 +63,10 @@ class AuthenticationInterceptorTests {
 	}
 
 	@Test
-	void preHandleStillRejectsDeletePresetRequestWithoutAuthenticationHeader() {
+	void preHandleStillRejectsDeleteApiPresetRequestWithoutAuthenticationHeader() {
 		AuthenticationTokenService authenticationTokenService = mock(AuthenticationTokenService.class);
 		AuthenticationInterceptor interceptor = new AuthenticationInterceptor(authenticationTokenService);
-		MockHttpServletRequest request = new MockHttpServletRequest("DELETE", "/presets/15");
+		MockHttpServletRequest request = new MockHttpServletRequest("DELETE", "/api/presets/15");
 		MockHttpServletResponse response = new MockHttpServletResponse();
 
 		assertThatThrownBy(() -> interceptor.preHandle(request, response, new Object()))

--- a/src/test/java/com/bdmage/mage_backend/controller/AccountLinkingControllerIntegrationTests.java
+++ b/src/test/java/com/bdmage/mage_backend/controller/AccountLinkingControllerIntegrationTests.java
@@ -46,7 +46,7 @@ class AccountLinkingControllerIntegrationTests extends PostgresIntegrationTestSu
 
 		this.userRepository.saveAndFlush(new User(email, this.passwordHashingService.hash(password), "Local User"));
 
-		this.mockMvc.perform(post("/auth/link/google")
+		this.mockMvc.perform(post("/api/auth/link/google")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(googleLinkRequestBody(email, password, verifiedToken(googleSubject, email, "Google User"))))
 				.andExpect(status().isOk())
@@ -68,7 +68,7 @@ class AccountLinkingControllerIntegrationTests extends PostgresIntegrationTestSu
 
 		this.userRepository.saveAndFlush(User.google(email, googleSubject, "Google User"));
 
-		this.mockMvc.perform(post("/auth/link/local")
+		this.mockMvc.perform(post("/api/auth/link/local")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(localLinkRequestBody(verifiedToken(googleSubject, email, "Google User"), password)))
 				.andExpect(status().isOk())
@@ -89,7 +89,7 @@ class AccountLinkingControllerIntegrationTests extends PostgresIntegrationTestSu
 
 		this.userRepository.saveAndFlush(new User(email, this.passwordHashingService.hash(password), "Local User"));
 
-		this.mockMvc.perform(post("/auth/link/google")
+		this.mockMvc.perform(post("/api/auth/link/google")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(googleLinkRequestBody(
 						email,
@@ -113,3 +113,4 @@ class AccountLinkingControllerIntegrationTests extends PostgresIntegrationTestSu
 		return "{\"idToken\":\"" + idToken + "\",\"password\":\"" + password + "\"}";
 	}
 }
+

--- a/src/test/java/com/bdmage/mage_backend/controller/AuthControllerTests.java
+++ b/src/test/java/com/bdmage/mage_backend/controller/AuthControllerTests.java
@@ -75,7 +75,7 @@ class AuthControllerTests {
 				.thenReturn(new GoogleAuthenticationResult(googleUser, true));
 		when(this.authenticationTokenService.issueToken(googleUser)).thenReturn("issued-google-token");
 
-		this.mockMvc.perform(post("/auth/google")
+		this.mockMvc.perform(post("/api/auth/google")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 						{"idToken":"valid-token"}
@@ -99,7 +99,7 @@ class AuthControllerTests {
 				.thenReturn(new GoogleAuthenticationResult(googleUser, false));
 		when(this.authenticationTokenService.issueToken(googleUser)).thenReturn("reissued-google-token");
 
-		this.mockMvc.perform(post("/auth/google")
+		this.mockMvc.perform(post("/api/auth/google")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 						{"idToken":"repeat-token"}
@@ -112,7 +112,7 @@ class AuthControllerTests {
 
 	@Test
 	void googleAuthenticationRejectsBlankTokenRequest() throws Exception {
-		this.mockMvc.perform(post("/auth/google")
+		this.mockMvc.perform(post("/api/auth/google")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 						{"idToken":" "}
@@ -127,7 +127,7 @@ class AuthControllerTests {
 		when(this.googleAuthenticationService.authenticate("invalid-token"))
 				.thenThrow(new InvalidGoogleTokenException("Google ID token is invalid or expired."));
 
-		this.mockMvc.perform(post("/auth/google")
+		this.mockMvc.perform(post("/api/auth/google")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 						{"idToken":"invalid-token"}
@@ -141,9 +141,9 @@ class AuthControllerTests {
 	void googleAuthenticationReturnsConflictWhenAccountRulesConflict() throws Exception {
 		when(this.googleAuthenticationService.authenticate("conflict-token"))
 				.thenThrow(new AccountLinkRequiredException(
-						"A local account already exists for this email. Link Google through /auth/link/google after authenticating that local account."));
+						"A local account already exists for this email. Link Google through /api/auth/link/google after authenticating that local account."));
 
-		this.mockMvc.perform(post("/auth/google")
+		this.mockMvc.perform(post("/api/auth/google")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 						{"idToken":"conflict-token"}
@@ -160,7 +160,7 @@ class AuthControllerTests {
 		when(this.registrationService.register("new-user@example.com", "secret-value", "New User"))
 				.thenReturn(localUser);
 
-		this.mockMvc.perform(post("/auth/register")
+		this.mockMvc.perform(post("/api/auth/register")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 						{"email":"new-user@example.com","password":"secret-value","displayName":"New User"}
@@ -177,7 +177,7 @@ class AuthControllerTests {
 
 	@Test
 	void registrationRejectsInvalidRequestBody() throws Exception {
-		this.mockMvc.perform(post("/auth/register")
+		this.mockMvc.perform(post("/api/auth/register")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 						{"email":" ","password":" ","displayName":" "}
@@ -195,7 +195,7 @@ class AuthControllerTests {
 				.thenThrow(new EmailAlreadyRegisteredException(
 						"Local authentication is already configured for this email."));
 
-		this.mockMvc.perform(post("/auth/register")
+		this.mockMvc.perform(post("/api/auth/register")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 						{"email":"existing@example.com","password":"secret-value","displayName":"Existing User"}
@@ -209,9 +209,9 @@ class AuthControllerTests {
 	void registrationReturnsConflictWhenExplicitLinkIsRequired() throws Exception {
 		when(this.registrationService.register("existing@example.com", "secret-value", "Existing User"))
 				.thenThrow(new AccountLinkRequiredException(
-						"A Google-backed account already exists for this email. Link local authentication through /auth/link/local after authenticating with Google."));
+						"A Google-backed account already exists for this email. Link local authentication through /api/auth/link/local after authenticating with Google."));
 
-		this.mockMvc.perform(post("/auth/register")
+		this.mockMvc.perform(post("/api/auth/register")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 						{"email":"existing@example.com","password":"secret-value","displayName":"Existing User"}
@@ -229,7 +229,7 @@ class AuthControllerTests {
 				.thenReturn(localUser);
 		when(this.authenticationTokenService.issueToken(localUser)).thenReturn("issued-login-token");
 
-		this.mockMvc.perform(post("/auth/login")
+		this.mockMvc.perform(post("/api/auth/login")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 						{"email":"local-user@example.com","password":"secret-value"}
@@ -247,7 +247,7 @@ class AuthControllerTests {
 
 	@Test
 	void loginRejectsInvalidRequestBody() throws Exception {
-		this.mockMvc.perform(post("/auth/login")
+		this.mockMvc.perform(post("/api/auth/login")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 						{"email":" ","password":" "}
@@ -263,7 +263,7 @@ class AuthControllerTests {
 		when(this.loginService.login("local-user@example.com", "wrong-password"))
 				.thenThrow(new InvalidCredentialsException("Email or password is incorrect."));
 
-		this.mockMvc.perform(post("/auth/login")
+		this.mockMvc.perform(post("/api/auth/login")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 						{"email":"local-user@example.com","password":"wrong-password"}
@@ -285,7 +285,7 @@ class AuthControllerTests {
 		when(this.accountLinkingService.linkGoogle("user@example.com", "secret-value", "valid-token"))
 				.thenReturn(new AccountLinkingResult(linkedUser, true));
 
-		this.mockMvc.perform(post("/auth/link/google")
+		this.mockMvc.perform(post("/api/auth/link/google")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 						{"email":"user@example.com","password":"secret-value","idToken":"valid-token"}
@@ -301,7 +301,7 @@ class AuthControllerTests {
 		when(this.accountLinkingService.linkGoogle("user@example.com", "secret-value", "valid-token"))
 				.thenThrow(new InvalidLocalCredentialsException("Email or password is incorrect."));
 
-		this.mockMvc.perform(post("/auth/link/google")
+		this.mockMvc.perform(post("/api/auth/link/google")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 						{"email":"user@example.com","password":"secret-value","idToken":"valid-token"}
@@ -323,7 +323,7 @@ class AuthControllerTests {
 		when(this.accountLinkingService.linkLocal("valid-token", "secret-value"))
 				.thenReturn(new AccountLinkingResult(linkedUser, false));
 
-		this.mockMvc.perform(post("/auth/link/local")
+		this.mockMvc.perform(post("/api/auth/link/local")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 						{"idToken":"valid-token","password":"secret-value"}
@@ -334,3 +334,4 @@ class AuthControllerTests {
 				.andExpect(jsonPath("$.linked").value(false));
 	}
 }
+

--- a/src/test/java/com/bdmage/mage_backend/controller/GoogleAuthControllerIntegrationTests.java
+++ b/src/test/java/com/bdmage/mage_backend/controller/GoogleAuthControllerIntegrationTests.java
@@ -48,7 +48,7 @@ class GoogleAuthControllerIntegrationTests extends PostgresIntegrationTestSuppor
 		String token = verifiedToken(subject, email, "Google User");
 		long countBefore = this.userRepository.count();
 
-		this.mockMvc.perform(post("/auth/google")
+		this.mockMvc.perform(post("/api/auth/google")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(requestBody(token)))
 				.andExpect(status().isCreated())
@@ -59,7 +59,7 @@ class GoogleAuthControllerIntegrationTests extends PostgresIntegrationTestSuppor
 
 		User savedUser = this.userRepository.findByGoogleSubject(subject).orElseThrow();
 
-		this.mockMvc.perform(post("/auth/google")
+		this.mockMvc.perform(post("/api/auth/google")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(requestBody(token)))
 				.andExpect(status().isOk())
@@ -77,20 +77,20 @@ class GoogleAuthControllerIntegrationTests extends PostgresIntegrationTestSuppor
 		String email = "local-conflict-" + uniqueSuffix + "@example.com";
 		this.userRepository.saveAndFlush(new User(email, "hashed-password-value", "Local User"));
 
-		this.mockMvc.perform(post("/auth/google")
+		this.mockMvc.perform(post("/api/auth/google")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(requestBody(verifiedToken(subject, email, "Google User"))))
 				.andExpect(status().isConflict())
 				.andExpect(jsonPath("$.code").value("ACCOUNT_LINK_REQUIRED"))
 				.andExpect(jsonPath("$.message").value(
-						"A local account already exists for this email. Link Google through /auth/link/google after authenticating that local account."));
+						"A local account already exists for this email. Link Google through /api/auth/link/google after authenticating that local account."));
 
 		assertThat(this.userRepository.findByGoogleSubject(subject)).isEmpty();
 	}
 
 	@Test
 	void googleAuthenticationRejectsInvalidTokens() throws Exception {
-		this.mockMvc.perform(post("/auth/google")
+		this.mockMvc.perform(post("/api/auth/google")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(requestBody("invalid-token")))
 				.andExpect(status().isUnauthorized())
@@ -126,3 +126,4 @@ class GoogleAuthControllerIntegrationTests extends PostgresIntegrationTestSuppor
 		}
 	}
 }
+

--- a/src/test/java/com/bdmage/mage_backend/controller/LoginControllerIntegrationTests.java
+++ b/src/test/java/com/bdmage/mage_backend/controller/LoginControllerIntegrationTests.java
@@ -45,7 +45,7 @@ class LoginControllerIntegrationTests extends PostgresIntegrationTestSupport {
 				this.passwordHashingService.hash(password),
 				"Login User"));
 
-		this.mockMvc.perform(post("/auth/login")
+		this.mockMvc.perform(post("/api/auth/login")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(requestBody(email, password)))
 				.andExpect(status().isOk())
@@ -67,7 +67,7 @@ class LoginControllerIntegrationTests extends PostgresIntegrationTestSupport {
 				this.passwordHashingService.hash("correct-password"),
 				"Local User"));
 
-		this.mockMvc.perform(post("/auth/login")
+		this.mockMvc.perform(post("/api/auth/login")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(requestBody(email, "wrong-password")))
 				.andExpect(status().isUnauthorized())
@@ -85,7 +85,7 @@ class LoginControllerIntegrationTests extends PostgresIntegrationTestSupport {
 				"google-subject-" + uniqueSuffix,
 				"Google User"));
 
-		this.mockMvc.perform(post("/auth/login")
+		this.mockMvc.perform(post("/api/auth/login")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(requestBody(email, "some-password")))
 				.andExpect(status().isUnauthorized())
@@ -97,3 +97,4 @@ class LoginControllerIntegrationTests extends PostgresIntegrationTestSupport {
 		return "{\"email\":\"" + email + "\",\"password\":\"" + password + "\"}";
 	}
 }
+

--- a/src/test/java/com/bdmage/mage_backend/controller/PresetControllerIntegrationTests.java
+++ b/src/test/java/com/bdmage/mage_backend/controller/PresetControllerIntegrationTests.java
@@ -159,7 +159,7 @@ class PresetControllerIntegrationTests extends PostgresIntegrationTestSupport {
 
 	@Test
 	void attachTagToPresetReturnsUnauthorizedWhenRequestHasNoAuthenticationHeader() throws Exception {
-		this.mockMvc.perform(post("/presets/15/tags")
+		this.mockMvc.perform(post("/api/presets/15/tags")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 						{"tagId":7}
@@ -188,14 +188,14 @@ class PresetControllerIntegrationTests extends PostgresIntegrationTestSupport {
 						""")));
 		Tag savedTag = this.tagRepository.saveAndFlush(new Tag(tagName));
 
-		String accessToken = accessToken(this.mockMvc.perform(post("/auth/login")
+		String accessToken = accessToken(this.mockMvc.perform(post("/api/auth/login")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(loginRequestBody(email, password)))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.accessToken").isNotEmpty())
 				.andReturn());
 
-		this.mockMvc.perform(post("/presets/" + savedPreset.getId() + "/tags")
+		this.mockMvc.perform(post("/api/presets/" + savedPreset.getId() + "/tags")
 				.header("Authorization", "Bearer " + accessToken)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
@@ -230,14 +230,14 @@ class PresetControllerIntegrationTests extends PostgresIntegrationTestSupport {
 		Tag savedTag = this.tagRepository.saveAndFlush(new Tag(tagName));
 		this.presetTagRepository.saveAndFlush(new PresetTag(savedPreset.getId(), savedTag.getId()));
 
-		String accessToken = accessToken(this.mockMvc.perform(post("/auth/login")
+		String accessToken = accessToken(this.mockMvc.perform(post("/api/auth/login")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(loginRequestBody(email, password)))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.accessToken").isNotEmpty())
 				.andReturn());
 
-		this.mockMvc.perform(post("/presets/" + savedPreset.getId() + "/tags")
+		this.mockMvc.perform(post("/api/presets/" + savedPreset.getId() + "/tags")
 				.header("Authorization", "Bearer " + accessToken)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
@@ -267,14 +267,14 @@ class PresetControllerIntegrationTests extends PostgresIntegrationTestSupport {
 						{"visualizer":{"shader":"glacier"}}
 						""")));
 
-		String accessToken = accessToken(this.mockMvc.perform(post("/auth/login")
+		String accessToken = accessToken(this.mockMvc.perform(post("/api/auth/login")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(loginRequestBody(email, password)))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.accessToken").isNotEmpty())
 				.andReturn());
 
-		this.mockMvc.perform(post("/presets/" + savedPreset.getId() + "/tags")
+		this.mockMvc.perform(post("/api/presets/" + savedPreset.getId() + "/tags")
 				.header("Authorization", "Bearer " + accessToken)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
@@ -287,7 +287,7 @@ class PresetControllerIntegrationTests extends PostgresIntegrationTestSupport {
 
 	@Test
 	void getPresetsReturnsUnauthorizedWhenRequestHasNoAuthenticationHeader() throws Exception {
-		this.mockMvc.perform(get("/presets")
+		this.mockMvc.perform(get("/api/presets")
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isUnauthorized())
 				.andExpect(jsonPath("$.code").value("AUTHENTICATION_REQUIRED"))
@@ -323,14 +323,14 @@ class PresetControllerIntegrationTests extends PostgresIntegrationTestSupport {
 		this.presetTagRepository.saveAndFlush(new PresetTag(ambientPreset.getId(), ambientTag.getId()));
 		this.presetTagRepository.saveAndFlush(new PresetTag(otherPreset.getId(), showcaseTag.getId()));
 
-		String accessToken = accessToken(this.mockMvc.perform(post("/auth/login")
+		String accessToken = accessToken(this.mockMvc.perform(post("/api/auth/login")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(loginRequestBody(email, password)))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.accessToken").isNotEmpty())
 				.andReturn());
 
-		this.mockMvc.perform(get("/presets")
+		this.mockMvc.perform(get("/api/presets")
 				.header("Authorization", "Bearer " + accessToken)
 				.param("tag", " " + ambientTagName.toUpperCase() + " ")
 				.contentType(MediaType.APPLICATION_JSON))
@@ -351,14 +351,14 @@ class PresetControllerIntegrationTests extends PostgresIntegrationTestSupport {
 				this.passwordHashingService.hash(password),
 				"Empty Filter Presets User"));
 
-		String accessToken = accessToken(this.mockMvc.perform(post("/auth/login")
+		String accessToken = accessToken(this.mockMvc.perform(post("/api/auth/login")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(loginRequestBody(email, password)))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.accessToken").isNotEmpty())
 				.andReturn());
 
-		this.mockMvc.perform(get("/presets")
+		this.mockMvc.perform(get("/api/presets")
 				.header("Authorization", "Bearer " + accessToken)
 				.param("tag", "ambient")
 				.contentType(MediaType.APPLICATION_JSON))
@@ -407,7 +407,7 @@ class PresetControllerIntegrationTests extends PostgresIntegrationTestSupport {
 				this.passwordHashingService.hash(password),
 				"Get Preset User"));
 
-		String accessToken = accessToken(this.mockMvc.perform(post("/auth/login")
+		String accessToken = accessToken(this.mockMvc.perform(post("/api/auth/login")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(loginRequestBody(email, password)))
 				.andExpect(status().isOk())
@@ -422,7 +422,7 @@ class PresetControllerIntegrationTests extends PostgresIntegrationTestSupport {
 						"""),
 				"thumbnails/preset-1.png"));
 
-		this.mockMvc.perform(get("/presets/" + savedPreset.getId())
+		this.mockMvc.perform(get("/api/presets/" + savedPreset.getId())
 				.header("Authorization", "Bearer " + accessToken)
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk())
@@ -446,7 +446,7 @@ class PresetControllerIntegrationTests extends PostgresIntegrationTestSupport {
 
 	@Test
 	void deletePresetReturnsUnauthorizedWhenRequestHasNoAuthenticationHeader() throws Exception {
-		this.mockMvc.perform(delete("/presets/15")
+		this.mockMvc.perform(delete("/api/presets/15")
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isUnauthorized())
 				.andExpect(jsonPath("$.code").value("AUTHENTICATION_REQUIRED"))
@@ -473,14 +473,14 @@ class PresetControllerIntegrationTests extends PostgresIntegrationTestSupport {
 		Tag savedTag = this.tagRepository.saveAndFlush(new Tag(tagName));
 		this.presetTagRepository.saveAndFlush(new PresetTag(savedPreset.getId(), savedTag.getId()));
 
-		String accessToken = accessToken(this.mockMvc.perform(post("/auth/login")
+		String accessToken = accessToken(this.mockMvc.perform(post("/api/auth/login")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(loginRequestBody(email, password)))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.accessToken").isNotEmpty())
 				.andReturn());
 
-		this.mockMvc.perform(delete("/presets/" + savedPreset.getId())
+		this.mockMvc.perform(delete("/api/presets/" + savedPreset.getId())
 				.header("Authorization", "Bearer " + accessToken)
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isNoContent());
@@ -488,14 +488,14 @@ class PresetControllerIntegrationTests extends PostgresIntegrationTestSupport {
 		assertThat(this.presetRepository.findById(savedPreset.getId())).isEmpty();
 		assertThat(this.presetTagRepository.findAllByPresetId(savedPreset.getId())).isEmpty();
 
-		this.mockMvc.perform(get("/presets/" + savedPreset.getId())
+		this.mockMvc.perform(get("/api/presets/" + savedPreset.getId())
 				.header("Authorization", "Bearer " + accessToken)
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isNotFound())
 				.andExpect(jsonPath("$.code").value("PRESET_NOT_FOUND"))
 				.andExpect(jsonPath("$.message").value("Preset not found."));
 
-		this.mockMvc.perform(get("/users/" + savedUser.getId() + "/presets")
+		this.mockMvc.perform(get("/api/users/" + savedUser.getId() + "/presets")
 				.header("Authorization", "Bearer " + accessToken)
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk())
@@ -525,14 +525,14 @@ class PresetControllerIntegrationTests extends PostgresIntegrationTestSupport {
 						{"visualizer":{"shader":"pulse"}}
 						""")));
 
-		String accessToken = accessToken(this.mockMvc.perform(post("/auth/login")
+		String accessToken = accessToken(this.mockMvc.perform(post("/api/auth/login")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(loginRequestBody(otherEmail, otherPassword)))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.accessToken").isNotEmpty())
 				.andReturn());
 
-		this.mockMvc.perform(delete("/presets/" + savedPreset.getId())
+		this.mockMvc.perform(delete("/api/presets/" + savedPreset.getId())
 				.header("Authorization", "Bearer " + accessToken)
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isForbidden())
@@ -553,14 +553,14 @@ class PresetControllerIntegrationTests extends PostgresIntegrationTestSupport {
 				this.passwordHashingService.hash(password),
 				"Delete Missing Preset User"));
 
-		String accessToken = accessToken(this.mockMvc.perform(post("/auth/login")
+		String accessToken = accessToken(this.mockMvc.perform(post("/api/auth/login")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(loginRequestBody(email, password)))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.accessToken").isNotEmpty())
 				.andReturn());
 
-		this.mockMvc.perform(delete("/presets/99999")
+		this.mockMvc.perform(delete("/api/presets/99999")
 				.header("Authorization", "Bearer " + accessToken)
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isNotFound())
@@ -586,3 +586,5 @@ class PresetControllerIntegrationTests extends PostgresIntegrationTestSupport {
 		return Long.valueOf(matcher.group(1));
 	}
 }
+
+

--- a/src/test/java/com/bdmage/mage_backend/controller/PresetControllerIntegrationTests.java
+++ b/src/test/java/com/bdmage/mage_backend/controller/PresetControllerIntegrationTests.java
@@ -61,7 +61,7 @@ class PresetControllerIntegrationTests extends PostgresIntegrationTestSupport {
 
 	@Test
 	void createPresetReturnsUnauthorizedWhenRequestHasNoAuthenticationHeader() throws Exception {
-		this.mockMvc.perform(post("/presets")
+		this.mockMvc.perform(post("/api/presets")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 						{
@@ -85,7 +85,7 @@ class PresetControllerIntegrationTests extends PostgresIntegrationTestSupport {
 				this.passwordHashingService.hash(password),
 				"Preset User"));
 
-		MvcResult loginResult = this.mockMvc.perform(post("/auth/login")
+		MvcResult loginResult = this.mockMvc.perform(post("/api/auth/login")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(loginRequestBody(email, password)))
 				.andExpect(status().isOk())
@@ -94,7 +94,7 @@ class PresetControllerIntegrationTests extends PostgresIntegrationTestSupport {
 
 		String accessToken = accessToken(loginResult);
 
-		MvcResult createResult = this.mockMvc.perform(post("/presets")
+		MvcResult createResult = this.mockMvc.perform(post("/api/presets")
 				.header("Authorization", "Bearer " + accessToken)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
@@ -133,7 +133,7 @@ class PresetControllerIntegrationTests extends PostgresIntegrationTestSupport {
 				this.passwordHashingService.hash(password),
 				"Preset Validation User"));
 
-		MvcResult loginResult = this.mockMvc.perform(post("/auth/login")
+		MvcResult loginResult = this.mockMvc.perform(post("/api/auth/login")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(loginRequestBody(email, password)))
 				.andExpect(status().isOk())
@@ -142,7 +142,7 @@ class PresetControllerIntegrationTests extends PostgresIntegrationTestSupport {
 
 		String accessToken = accessToken(loginResult);
 
-		this.mockMvc.perform(post("/presets")
+		this.mockMvc.perform(post("/api/presets")
 				.header("Authorization", "Bearer " + accessToken)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
@@ -384,7 +384,7 @@ class PresetControllerIntegrationTests extends PostgresIntegrationTestSupport {
 						"""),
 				"thumbnails/preset-1.png"));
 
-		this.mockMvc.perform(get("/presets/" + savedPreset.getId())
+		this.mockMvc.perform(get("/api/presets/" + savedPreset.getId())
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.presetId").value(savedPreset.getId()))
@@ -437,7 +437,7 @@ class PresetControllerIntegrationTests extends PostgresIntegrationTestSupport {
 
 	@Test
 	void getPresetReturnsNotFoundForPublicRequestWhenPresetDoesNotExist() throws Exception {
-		this.mockMvc.perform(get("/presets/99999")
+		this.mockMvc.perform(get("/api/presets/99999")
 				.contentType(MediaType.APPLICATION_JSON))
 				.andExpect(status().isNotFound())
 				.andExpect(jsonPath("$.code").value("PRESET_NOT_FOUND"))

--- a/src/test/java/com/bdmage/mage_backend/controller/PresetControllerTests.java
+++ b/src/test/java/com/bdmage/mage_backend/controller/PresetControllerTests.java
@@ -79,7 +79,7 @@ class PresetControllerTests {
 				"thumbnails/preset-1.png"))
 				.thenReturn(preset);
 
-		this.mockMvc.perform(post("/presets")
+		this.mockMvc.perform(post("/api/presets")
 				.requestAttr(AuthenticatedUserRequest.USER_ID_ATTRIBUTE, 77L)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
@@ -102,7 +102,7 @@ class PresetControllerTests {
 
 	@Test
 	void createPresetRejectsInvalidRequestBody() throws Exception {
-		this.mockMvc.perform(post("/presets")
+		this.mockMvc.perform(post("/api/presets")
 				.requestAttr(AuthenticatedUserRequest.USER_ID_ATTRIBUTE, 77L)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
@@ -129,7 +129,7 @@ class PresetControllerTests {
 				null))
 				.thenThrow(new AuthenticationRequiredException("Authentication is required."));
 
-		this.mockMvc.perform(post("/presets")
+		this.mockMvc.perform(post("/api/presets")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 						{
@@ -163,7 +163,7 @@ class PresetControllerTests {
 
 		when(this.presetService.getAllPresets()).thenReturn(List.of(firstPreset, secondPreset));
 
-		this.mockMvc.perform(get("/presets"))
+		this.mockMvc.perform(get("/api/presets"))
 				.andExpect(status().isOk())
 				.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
 				.andExpect(jsonPath("$[0].presetId").value(15L))
@@ -185,7 +185,7 @@ class PresetControllerTests {
 
 		when(this.presetService.getPresetsByTag("ambient")).thenReturn(List.of(preset));
 
-		this.mockMvc.perform(get("/presets").param("tag", "ambient"))
+		this.mockMvc.perform(get("/api/presets").param("tag", "ambient"))
 				.andExpect(status().isOk())
 				.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
 				.andExpect(jsonPath("$[0].presetId").value(15L))
@@ -196,7 +196,7 @@ class PresetControllerTests {
 	void getPresetsReturnsEmptyListWhenNoPresetsMatchTagFilter() throws Exception {
 		when(this.presetService.getPresetsByTag("ambient")).thenReturn(List.of());
 
-		this.mockMvc.perform(get("/presets").param("tag", "ambient"))
+		this.mockMvc.perform(get("/api/presets").param("tag", "ambient"))
 				.andExpect(status().isOk())
 				.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
 				.andExpect(content().json("[]"));
@@ -209,7 +209,7 @@ class PresetControllerTests {
 		when(this.presetService.attachTagToPreset(77L, 15L, 7L))
 				.thenReturn(presetTag);
 
-		this.mockMvc.perform(post("/presets/15/tags")
+		this.mockMvc.perform(post("/api/presets/15/tags")
 				.requestAttr(AuthenticatedUserRequest.USER_ID_ATTRIBUTE, 77L)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
@@ -223,7 +223,7 @@ class PresetControllerTests {
 
 	@Test
 	void attachTagToPresetRejectsInvalidRequestBody() throws Exception {
-		this.mockMvc.perform(post("/presets/15/tags")
+		this.mockMvc.perform(post("/api/presets/15/tags")
 				.requestAttr(AuthenticatedUserRequest.USER_ID_ATTRIBUTE, 77L)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
@@ -239,7 +239,7 @@ class PresetControllerTests {
 		when(this.presetService.attachTagToPreset(null, 15L, 7L))
 				.thenThrow(new AuthenticationRequiredException("Authentication is required."));
 
-		this.mockMvc.perform(post("/presets/15/tags")
+		this.mockMvc.perform(post("/api/presets/15/tags")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 						{"tagId":7}
@@ -254,7 +254,7 @@ class PresetControllerTests {
 		when(this.presetService.attachTagToPreset(77L, 15L, 7L))
 				.thenThrow(new TagNotFoundException("Tag not found."));
 
-		this.mockMvc.perform(post("/presets/15/tags")
+		this.mockMvc.perform(post("/api/presets/15/tags")
 				.requestAttr(AuthenticatedUserRequest.USER_ID_ATTRIBUTE, 77L)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
@@ -270,7 +270,7 @@ class PresetControllerTests {
 		when(this.presetService.attachTagToPreset(77L, 15L, 7L))
 				.thenThrow(new PresetTagAlreadyExistsException("This tag is already attached to the preset."));
 
-		this.mockMvc.perform(post("/presets/15/tags")
+		this.mockMvc.perform(post("/api/presets/15/tags")
 				.requestAttr(AuthenticatedUserRequest.USER_ID_ATTRIBUTE, 77L)
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
@@ -295,7 +295,7 @@ class PresetControllerTests {
 
 		when(this.presetService.getPreset(15L)).thenReturn(preset);
 
-		this.mockMvc.perform(get("/presets/15"))
+		this.mockMvc.perform(get("/api/presets/15"))
 				.andExpect(status().isOk())
 				.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
 				.andExpect(jsonPath("$.presetId").value(15L))
@@ -312,7 +312,7 @@ class PresetControllerTests {
 		when(this.presetService.getPreset(99999L))
 				.thenThrow(new PresetNotFoundException("Preset not found."));
 
-		this.mockMvc.perform(get("/presets/99999"))
+		this.mockMvc.perform(get("/api/presets/99999"))
 				.andExpect(status().isNotFound())
 				.andExpect(jsonPath("$.code").value("PRESET_NOT_FOUND"))
 				.andExpect(jsonPath("$.message").value("Preset not found."));
@@ -320,7 +320,7 @@ class PresetControllerTests {
 
 	@Test
 	void deletePresetReturnsNoContentForAuthenticatedOwner() throws Exception {
-		this.mockMvc.perform(delete("/presets/15")
+		this.mockMvc.perform(delete("/api/presets/15")
 				.requestAttr(AuthenticatedUserRequest.USER_ID_ATTRIBUTE, 77L))
 				.andExpect(status().isNoContent())
 				.andExpect(content().string(""));
@@ -332,7 +332,7 @@ class PresetControllerTests {
 				.when(this.presetService)
 				.deletePreset(null, 15L);
 
-		this.mockMvc.perform(delete("/presets/15"))
+		this.mockMvc.perform(delete("/api/presets/15"))
 				.andExpect(status().isUnauthorized())
 				.andExpect(jsonPath("$.code").value("AUTHENTICATION_REQUIRED"))
 				.andExpect(jsonPath("$.message").value("Authentication is required."));
@@ -344,7 +344,7 @@ class PresetControllerTests {
 				.when(this.presetService)
 				.deletePreset(77L, 15L);
 
-		this.mockMvc.perform(delete("/presets/15")
+		this.mockMvc.perform(delete("/api/presets/15")
 				.requestAttr(AuthenticatedUserRequest.USER_ID_ATTRIBUTE, 77L))
 				.andExpect(status().isForbidden())
 				.andExpect(jsonPath("$.code").value("PRESET_FORBIDDEN"))
@@ -357,10 +357,12 @@ class PresetControllerTests {
 				.when(this.presetService)
 				.deletePreset(77L, 15L);
 
-		this.mockMvc.perform(delete("/presets/15")
+		this.mockMvc.perform(delete("/api/presets/15")
 				.requestAttr(AuthenticatedUserRequest.USER_ID_ATTRIBUTE, 77L))
 				.andExpect(status().isNotFound())
 				.andExpect(jsonPath("$.code").value("PRESET_NOT_FOUND"))
 				.andExpect(jsonPath("$.message").value("Preset not found."));
 	}
 }
+
+

--- a/src/test/java/com/bdmage/mage_backend/controller/RegistrationControllerIntegrationTests.java
+++ b/src/test/java/com/bdmage/mage_backend/controller/RegistrationControllerIntegrationTests.java
@@ -42,7 +42,7 @@ class RegistrationControllerIntegrationTests extends PostgresIntegrationTestSupp
 		String password = "password-" + uniqueSuffix;
 		String displayName = "Local User";
 
-		this.mockMvc.perform(post("/auth/register")
+		this.mockMvc.perform(post("/api/auth/register")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(requestBody(email, password, displayName)))
 				.andExpect(status().isCreated())
@@ -66,7 +66,7 @@ class RegistrationControllerIntegrationTests extends PostgresIntegrationTestSupp
 
 		this.userRepository.saveAndFlush(new User(email, "hashed-password-value", "Local User"));
 
-		this.mockMvc.perform(post("/auth/register")
+		this.mockMvc.perform(post("/api/auth/register")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(requestBody(email, password, "Local User")))
 				.andExpect(status().isConflict())
@@ -82,16 +82,17 @@ class RegistrationControllerIntegrationTests extends PostgresIntegrationTestSupp
 
 		this.userRepository.saveAndFlush(User.google(email, "google-subject-" + uniqueSuffix, "Google User"));
 
-		this.mockMvc.perform(post("/auth/register")
+		this.mockMvc.perform(post("/api/auth/register")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(requestBody(email, password, "Local User")))
 				.andExpect(status().isConflict())
 				.andExpect(jsonPath("$.code").value("ACCOUNT_LINK_REQUIRED"))
 				.andExpect(jsonPath("$.message").value(
-						"A Google-backed account already exists for this email. Link local authentication through /auth/link/local after authenticating with Google."));
+						"A Google-backed account already exists for this email. Link local authentication through /api/auth/link/local after authenticating with Google."));
 	}
 
 	private static String requestBody(String email, String password, String displayName) {
 		return "{\"email\":\"" + email + "\",\"password\":\"" + password + "\",\"displayName\":\"" + displayName + "\"}";
 	}
 }
+

--- a/src/test/java/com/bdmage/mage_backend/controller/TagControllerIntegrationTests.java
+++ b/src/test/java/com/bdmage/mage_backend/controller/TagControllerIntegrationTests.java
@@ -39,7 +39,7 @@ class TagControllerIntegrationTests extends PostgresIntegrationTestSupport {
 
 	@Test
 	void createTagPersistsNormalizedTag() throws Exception {
-		this.mockMvc.perform(post("/tags")
+		this.mockMvc.perform(post("/api/tags")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 						{"name":"  Chillwave  "}
@@ -57,7 +57,7 @@ class TagControllerIntegrationTests extends PostgresIntegrationTestSupport {
 	void createTagReturnsConflictWhenTagAlreadyExists() throws Exception {
 		this.tagRepository.saveAndFlush(new Tag("ambient"));
 
-		this.mockMvc.perform(post("/tags")
+		this.mockMvc.perform(post("/api/tags")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 						{"name":"  AMBIENT  "}
@@ -71,7 +71,7 @@ class TagControllerIntegrationTests extends PostgresIntegrationTestSupport {
 
 	@Test
 	void createTagRejectsInvalidRequestBody() throws Exception {
-		this.mockMvc.perform(post("/tags")
+		this.mockMvc.perform(post("/api/tags")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 						{"name":" "}
@@ -81,3 +81,4 @@ class TagControllerIntegrationTests extends PostgresIntegrationTestSupport {
 				.andExpect(jsonPath("$.details.name").value("name must not be blank"));
 	}
 }
+

--- a/src/test/java/com/bdmage/mage_backend/controller/TagControllerTests.java
+++ b/src/test/java/com/bdmage/mage_backend/controller/TagControllerTests.java
@@ -50,7 +50,7 @@ class TagControllerTests {
 
 		when(this.tagService.createTag("Ambient")).thenReturn(tag);
 
-		this.mockMvc.perform(post("/tags")
+		this.mockMvc.perform(post("/api/tags")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 						{"name":"Ambient"}
@@ -63,7 +63,7 @@ class TagControllerTests {
 
 	@Test
 	void createTagRejectsInvalidRequestBody() throws Exception {
-		this.mockMvc.perform(post("/tags")
+		this.mockMvc.perform(post("/api/tags")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 						{"name":" "}
@@ -78,7 +78,7 @@ class TagControllerTests {
 		when(this.tagService.createTag("Ambient"))
 				.thenThrow(new TagAlreadyExistsException("A tag with this name already exists."));
 
-		this.mockMvc.perform(post("/tags")
+		this.mockMvc.perform(post("/api/tags")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
 						{"name":"Ambient"}
@@ -88,3 +88,4 @@ class TagControllerTests {
 				.andExpect(jsonPath("$.message").value("A tag with this name already exists."));
 	}
 }
+

--- a/src/test/java/com/bdmage/mage_backend/controller/UserControllerIntegrationTests.java
+++ b/src/test/java/com/bdmage/mage_backend/controller/UserControllerIntegrationTests.java
@@ -58,7 +58,7 @@ class UserControllerIntegrationTests extends PostgresIntegrationTestSupport {
 
 	@Test
 	void meReturnsUnauthorizedWhenRequestHasNoAuthenticationHeader() throws Exception {
-		this.mockMvc.perform(get("/users/me"))
+		this.mockMvc.perform(get("/api/users/me"))
 				.andExpect(status().isUnauthorized())
 				.andExpect(jsonPath("$.code").value("AUTHENTICATION_REQUIRED"))
 				.andExpect(jsonPath("$.message").value("Authentication is required."));
@@ -84,7 +84,7 @@ class UserControllerIntegrationTests extends PostgresIntegrationTestSupport {
 				this.passwordHashingService.hash(password),
 				"Profile Local User"));
 
-		MvcResult loginResult = this.mockMvc.perform(post("/auth/login")
+		MvcResult loginResult = this.mockMvc.perform(post("/api/auth/login")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(loginRequestBody(email, password)))
 				.andExpect(status().isOk())
@@ -93,7 +93,7 @@ class UserControllerIntegrationTests extends PostgresIntegrationTestSupport {
 
 		String accessToken = accessToken(loginResult);
 
-		this.mockMvc.perform(get("/users/me")
+		this.mockMvc.perform(get("/api/users/me")
 				.header("Authorization", "Bearer " + accessToken))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.email").value(email))
@@ -155,7 +155,7 @@ class UserControllerIntegrationTests extends PostgresIntegrationTestSupport {
 		savePreset(ownerUser.getId(), "Aurora Drift");
 		savePreset(ownerUser.getId(), "Signal Bloom");
 
-		MvcResult loginResult = this.mockMvc.perform(post("/auth/login")
+		MvcResult loginResult = this.mockMvc.perform(post("/api/auth/login")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(loginRequestBody(authenticatedUser.getEmail(), "viewer-password-" + uniqueSuffix)))
 				.andExpect(status().isOk())
@@ -164,7 +164,7 @@ class UserControllerIntegrationTests extends PostgresIntegrationTestSupport {
 
 		String accessToken = accessToken(loginResult);
 
-		this.mockMvc.perform(get("/users/" + ownerUser.getId() + "/presets")
+		this.mockMvc.perform(get("/api/users/" + ownerUser.getId() + "/presets")
 				.header("Authorization", "Bearer " + accessToken))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.length()").value(2))

--- a/src/test/java/com/bdmage/mage_backend/controller/UserControllerIntegrationTests.java
+++ b/src/test/java/com/bdmage/mage_backend/controller/UserControllerIntegrationTests.java
@@ -66,7 +66,7 @@ class UserControllerIntegrationTests extends PostgresIntegrationTestSupport {
 
 	@Test
 	void meReturnsUnauthorizedWhenRequestUsesInvalidAuthenticationToken() throws Exception {
-		this.mockMvc.perform(get("/users/me")
+		this.mockMvc.perform(get("/api/users/me")
 				.header("Authorization", "Bearer invalid-token"))
 				.andExpect(status().isUnauthorized())
 				.andExpect(jsonPath("$.code").value("INVALID_AUTH_TOKEN"))
@@ -111,7 +111,7 @@ class UserControllerIntegrationTests extends PostgresIntegrationTestSupport {
 		String subject = "google-profile-" + uniqueSuffix;
 		String email = "profile-google-" + uniqueSuffix + "@example.com";
 
-		MvcResult authenticationResult = this.mockMvc.perform(post("/auth/google")
+		MvcResult authenticationResult = this.mockMvc.perform(post("/api/auth/google")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(googleRequestBody(verifiedToken(subject, email, "Profile Google User"))))
 				.andExpect(status().isCreated())
@@ -120,7 +120,7 @@ class UserControllerIntegrationTests extends PostgresIntegrationTestSupport {
 
 		String accessToken = accessToken(authenticationResult);
 
-		this.mockMvc.perform(get("/users/me")
+		this.mockMvc.perform(get("/api/users/me")
 				.header("Authorization", "Bearer " + accessToken))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.email").value(email))
@@ -134,7 +134,7 @@ class UserControllerIntegrationTests extends PostgresIntegrationTestSupport {
 
 	@Test
 	void presetsReturnsUnauthorizedWhenRequestHasNoAuthenticationHeader() throws Exception {
-		this.mockMvc.perform(get("/users/77/presets"))
+		this.mockMvc.perform(get("/api/users/77/presets"))
 				.andExpect(status().isUnauthorized())
 				.andExpect(jsonPath("$.code").value("AUTHENTICATION_REQUIRED"))
 				.andExpect(jsonPath("$.message").value("Authentication is required."));
@@ -189,7 +189,7 @@ class UserControllerIntegrationTests extends PostgresIntegrationTestSupport {
 				this.passwordHashingService.hash("empty-password-" + uniqueSuffix),
 				"Preset Empty"));
 
-		MvcResult loginResult = this.mockMvc.perform(post("/auth/login")
+		MvcResult loginResult = this.mockMvc.perform(post("/api/auth/login")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(loginRequestBody(authenticatedUser.getEmail(), "reader-password-" + uniqueSuffix)))
 				.andExpect(status().isOk())
@@ -198,7 +198,7 @@ class UserControllerIntegrationTests extends PostgresIntegrationTestSupport {
 
 		String accessToken = accessToken(loginResult);
 
-		this.mockMvc.perform(get("/users/" + requestedUser.getId() + "/presets")
+		this.mockMvc.perform(get("/api/users/" + requestedUser.getId() + "/presets")
 				.header("Authorization", "Bearer " + accessToken))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$").isArray())
@@ -255,3 +255,5 @@ class UserControllerIntegrationTests extends PostgresIntegrationTestSupport {
 		}
 	}
 }
+
+

--- a/src/test/java/com/bdmage/mage_backend/controller/UserControllerTests.java
+++ b/src/test/java/com/bdmage/mage_backend/controller/UserControllerTests.java
@@ -49,7 +49,7 @@ class UserControllerTests {
 
 		when(this.userProfileService.getAuthenticatedUser(51L)).thenReturn(user);
 
-		this.mockMvc.perform(get("/users/me")
+		this.mockMvc.perform(get("/api/users/me")
 				.requestAttr(AuthenticatedUserRequest.USER_ID_ATTRIBUTE, 51L))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.userId").value(51L))
@@ -67,7 +67,7 @@ class UserControllerTests {
 		when(this.userProfileService.getAuthenticatedUser(null))
 				.thenThrow(new AuthenticationRequiredException("Authentication is required."));
 
-		this.mockMvc.perform(get("/users/me"))
+		this.mockMvc.perform(get("/api/users/me"))
 				.andExpect(status().isUnauthorized())
 				.andExpect(jsonPath("$.code").value("AUTHENTICATION_REQUIRED"))
 				.andExpect(jsonPath("$.message").value("Authentication is required."));
@@ -81,7 +81,7 @@ class UserControllerTests {
 		when(this.presetService.getPresetsForUser(51L, 77L))
 				.thenReturn(List.of(firstPreset, secondPreset));
 
-		this.mockMvc.perform(get("/users/77/presets")
+		this.mockMvc.perform(get("/api/users/77/presets")
 				.requestAttr(AuthenticatedUserRequest.USER_ID_ATTRIBUTE, 51L))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$[0].presetId").value(15L))
@@ -98,7 +98,7 @@ class UserControllerTests {
 		when(this.presetService.getPresetsForUser(51L, 77L))
 				.thenReturn(List.of());
 
-		this.mockMvc.perform(get("/users/77/presets")
+		this.mockMvc.perform(get("/api/users/77/presets")
 				.requestAttr(AuthenticatedUserRequest.USER_ID_ATTRIBUTE, 51L))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$").isArray())
@@ -110,7 +110,7 @@ class UserControllerTests {
 		when(this.presetService.getPresetsForUser(null, 77L))
 				.thenThrow(new AuthenticationRequiredException("Authentication is required."));
 
-		this.mockMvc.perform(get("/users/77/presets"))
+		this.mockMvc.perform(get("/api/users/77/presets"))
 				.andExpect(status().isUnauthorized())
 				.andExpect(jsonPath("$.code").value("AUTHENTICATION_REQUIRED"))
 				.andExpect(jsonPath("$.message").value("Authentication is required."));
@@ -128,3 +128,5 @@ class UserControllerTests {
 		return preset;
 	}
 }
+
+

--- a/src/test/java/com/bdmage/mage_backend/service/AccountLinkingServiceTests.java
+++ b/src/test/java/com/bdmage/mage_backend/service/AccountLinkingServiceTests.java
@@ -139,7 +139,7 @@ class AccountLinkingServiceTests {
 
 		assertThatThrownBy(() -> accountLinkingService.linkLocal("valid-token", "secret-value"))
 				.isInstanceOf(AccountLinkRequiredException.class)
-				.hasMessage("Authenticate with Google through /auth/google before linking local authentication.");
+				.hasMessage("Authenticate with Google through /api/auth/google before linking local authentication.");
 	}
 
 	@Test
@@ -171,3 +171,4 @@ class AccountLinkingServiceTests {
 		assertThat(result.user().getAuthProvider()).isEqualTo(AuthProvider.LOCAL_GOOGLE);
 	}
 }
+

--- a/src/test/java/com/bdmage/mage_backend/service/GoogleAuthenticationServiceTests.java
+++ b/src/test/java/com/bdmage/mage_backend/service/GoogleAuthenticationServiceTests.java
@@ -130,7 +130,7 @@ class GoogleAuthenticationServiceTests {
 		assertThatThrownBy(() -> googleAuthenticationService.authenticate("conflict-token"))
 				.isInstanceOf(AccountLinkRequiredException.class)
 				.hasMessage(
-						"A local account already exists for this email. Link Google through /auth/link/google after authenticating that local account.");
+						"A local account already exists for this email. Link Google through /api/auth/link/google after authenticating that local account.");
 	}
 
 	@Test
@@ -181,3 +181,4 @@ class GoogleAuthenticationServiceTests {
 		assertThat(result.user().getId()).isEqualTo(128L);
 	}
 }
+

--- a/src/test/java/com/bdmage/mage_backend/service/RegistrationServiceTests.java
+++ b/src/test/java/com/bdmage/mage_backend/service/RegistrationServiceTests.java
@@ -75,9 +75,10 @@ class RegistrationServiceTests {
 		assertThatThrownBy(() -> registrationService.register("user@example.com", "plain-password", "New User"))
 				.isInstanceOf(AccountLinkRequiredException.class)
 				.hasMessage(
-						"A Google-backed account already exists for this email. Link local authentication through /auth/link/local after authenticating with Google.");
+						"A Google-backed account already exists for this email. Link local authentication through /api/auth/link/local after authenticating with Google.");
 
 		verify(passwordHashingService, never()).hash(any());
 		verify(userRepository, never()).saveAndFlush(any(User.class));
 	}
 }
+


### PR DESCRIPTION
## Summary
- expose backend auth, user, preset, and tag routes under `/api/...`
- update tests, docs, manual scripts, and service guidance strings to use the `/api` namespace consistently
- remove the temporary legacy unprefixed route mappings after the repo was fully migrated

## Problem
The frontend needed to keep `/presets/:id` as a React page route, but the backend also served `/presets/{id}` as an API route. In development, that collision caused direct browser visits to the preset detail page to hit the backend instead of the SPA. The backend needed an `/api` namespace so frontend page routes and API routes could coexist cleanly. After the initial namespace change, the repo still contained compatibility mappings and scattered old-route references that needed to be fully removed.

## What Changed
- moved the backend route surface to `/api/...` for:
  - `/api/auth`
  - `/api/users`
  - `/api/presets`
  - `/api/tags`
- updated the auth interceptor configuration to protect `/api/users/**` and `/api/presets/**`
- kept public preset-detail reads at `GET /api/presets/{id}`
- migrated remaining backend tests to `/api/...`
- updated backend docs and manual testing guides to `/api/...`
- updated route-guidance error messages in account-linking and auth services to point to `/api/auth/...`
- removed the old unprefixed controller mappings and old interceptor path coverage

## Testing
- mvn "-Dtest=AuthenticationInterceptorTests,PresetControllerIntegrationTests,UserControllerIntegrationTests" test
- mvn test

## Notes
- the backend no longer accepts the old unprefixed `/auth`, `/users`, `/presets`, and `/tags` routes