### PR TITLE
Docs/professional backend docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,55 +1,57 @@
 # Contributing
 
-A good contribution is small enough to review and clear enough that another developer can extend it without re-learning your intent from scratch.
+Keep changes small, focused, and easy to reason about.
 
-## Read Before You Change Code
+## Read First
+
+Before changing backend code, read:
 
 - [README.md](README.md)
-- [docs/getting-started.md](docs/getting-started.md)
+- [docs/README.md](docs/README.md)
 - [docs/architecture.md](docs/architecture.md)
 - [docs/engineering-standards.md](docs/engineering-standards.md)
-- [docs/operations.md](docs/operations.md)
+
+Use [docs/operations.md](docs/operations.md) when the change affects setup, runtime behavior, or troubleshooting guidance.
 
 ## Standard Workflow
 
-1. Pull the latest `main` branch.
-2. Create a focused branch for one feature, fix, or refactor.
-3. Start the backend locally and confirm the current behavior.
+1. Pull the latest `main`.
+2. Create a focused branch.
+3. Start the backend and confirm the current behavior.
 4. Make the change in the correct layer.
-5. Add or update a Flyway migration if the schema changes.
-6. Add or update tests for the behavior you changed.
-7. Update documentation if setup, configuration, architecture, or operations changed.
-8. Run the full test suite before opening a pull request.
+5. Add or update tests.
+6. Add a Flyway migration if the schema changes.
+7. Update docs if setup, architecture, or operations changed.
+8. Run the relevant checks before opening a pull request.
 
 ## Pull Request Expectations
 
-Every pull request should answer these questions clearly:
+Every PR should explain:
 
-- What changed?
-- Why was the change needed?
-- How was it tested?
-- Does it change the schema, environment variables, or public API?
-- What should a reviewer pay special attention to?
+- what changed
+- why it changed
+- how it was tested
+- whether it changes schema, configuration, or public API
+- any reviewer risk areas
 
-Keep pull requests focused:
-
-- avoid combining unrelated cleanup work with behavioral changes in the same pull request.
-- do not rename files or packages unless the change provides a clear architectural or maintainability benefit.
-- avoid including formatting-only changes unless the pull request is specifically intended to address formatting.
+Keep PRs reviewable:
+- avoid unrelated cleanup in behavior-changing PRs
+- do not mix refactors and feature work unless they are tightly coupled
+- avoid file churn that does not materially help the change
 
 ## Definition of Done
 
 A backend change is ready to merge when:
 
-- the code fits the repository's layer boundaries
+- the code fits the repository’s layers
 - tests cover the changed behavior
-- schema changes are captured in Flyway migrations
-- configuration changes are documented
-- the change is understandable to someone who did not write it
+- schema changes are represented with Flyway migrations
+- config or workflow changes are documented
+- the change is understandable to a reviewer without extra verbal context
 
 ## Quality Checks
 
-Run the full Maven wrapper test command before requesting review:
+Run the backend test suite before requesting review.
 
 Windows PowerShell:
 
@@ -63,17 +65,15 @@ macOS/Linux:
 ./mvnw test
 ```
 
-Because the suite uses Testcontainers, Docker must be running.
+Docker must be running because integration tests use Testcontainers.
 
 ## Review Mindset
 
-When you review someone else's backend change, look for:
-
+Prioritize:
 - correctness
 - architectural fit
-- maintainability
+- migration and configuration risk
 - missing tests
-- migration or configuration risk
 - API contract clarity
 
-The goal is not to find style nits in isolation. The goal is to keep the codebase predictable as it grows.
+Style concerns matter, but they are secondary to behavior and maintainability.

--- a/README.md
+++ b/README.md
@@ -1,28 +1,32 @@
 # MAGE Backend
 
-## Overview
+Spring Boot service for the MAGE platform.
 
-This backend is the Java and Spring Boot service for the MAGE platform. At its current stage, the repository provides the backend foundation plus the first account-authentication flows and preset persistence APIs: application startup, PostgreSQL connectivity, Flyway-managed schema migration, health and readiness endpoints, local account registration and login, Google authentication account provisioning, explicit local and Google account linking, bearer-token authentication middleware, current-user profile lookup, preset creation, preset detail retrieval, owner-only preset deletion, preset tag attachment, preset listing with optional tag filtering, user preset listing, Docker-based local development, and integrated testing.
+This repository currently provides the backend foundations for:
+- health and readiness checks
+- local account registration and login
+- Google authentication and explicit provider linking
+- bearer-token authentication for protected routes
+- user profile lookup
+- preset creation, retrieval, deletion, and user-scoped listing
+- tag creation and preset tagging
 
-The codebase is small at the moment, but the documentation and engineering expectations are structured like a team-owned backend project. New contributors should be able to clone the repository, run it locally, understand the architecture, and make disciplined changes without relying on extra explanation.
-
-## Tech Stack
+## Stack
 
 - Java 21
-- Spring Boot 4.0.3
+- Spring Boot 4
 - Spring Web MVC
-- Spring Security Crypto
 - Spring Data JPA
 - PostgreSQL 16
 - Flyway
 - Google API Client
 - Maven Wrapper
-- JUnit 5, AssertJ, Mockito, and Testcontainers
-- Docker and Docker Compose
+- JUnit 5, Mockito, AssertJ, Testcontainers
+- Docker Compose
 
-## Quick Start
+## Getting Started
 
-For a first run, use the Docker workflow.
+The default local workflow uses Docker Compose.
 
 Windows PowerShell:
 
@@ -38,26 +42,12 @@ cp .env.example .env
 docker compose up --build
 ```
 
-Once the stack is healthy:
+Once the stack is up:
+- app: `http://localhost:8080`
+- liveness: `GET /health`
+- readiness: `GET /ready`
 
-- backend: `http://localhost:8080`
-- liveness: `http://localhost:8080/health`
-- readiness: `http://localhost:8080/ready`
-- local registration: `POST http://localhost:8080/api/auth/register`
-- local login: `POST http://localhost:8080/api/auth/login`
-- Google auth: `POST http://localhost:8080/api/auth/google`
-- link Google to an existing local account: `POST http://localhost:8080/api/auth/link/google`
-- link local auth to an existing Google-backed account: `POST http://localhost:8080/api/auth/link/local`
-- current user profile: `GET http://localhost:8080/api/users/me`
-- preset creation: `POST http://localhost:8080/api/presets`
-- preset list: `GET http://localhost:8080/api/presets`
-- preset list filtered by tag: `GET http://localhost:8080/api/presets?tag=ambient`
-- preset detail: `GET http://localhost:8080/api/presets/{id}`
-- preset deletion: `DELETE http://localhost:8080/api/presets/{id}`
-- preset tag attachment: `POST http://localhost:8080/api/presets/{id}/tags`
-- user preset list: `GET http://localhost:8080/api/users/{id}/presets`
-
-Run the test suite with:
+Run tests with:
 
 Windows PowerShell:
 
@@ -71,61 +61,85 @@ macOS/Linux:
 ./mvnw test
 ```
 
-## Environment and Local Run Notes
+The test suite uses Testcontainers, so Docker must be running.
 
-- `.env.example` is designed for Docker Compose.
-- `MAGE_AUTH_GOOGLE_CLIENT_IDS` must contain the Google OAuth client ID used by the frontend.
-- if the backend runs inside Docker, the datasource host is `postgres`
-- Flyway runs automatically during application startup
-- the test suite requires Docker because integration tests use Testcontainers
+## Configuration
 
-Full local setup instructions live in [docs/getting-started.md](docs/getting-started.md).
+The backend reads configuration from environment variables. The local Docker setup is driven by `.env`.
 
-## Project Structure
+Required values for local development:
+
+| Variable | Purpose |
+| --- | --- |
+| `SERVER_PORT` | Backend HTTP port. Defaults to `8080`. |
+| `MAGE_AUTH_GOOGLE_CLIENT_IDS` | Allowed Google OAuth client IDs for server-side ID token verification. |
+| `SPRING_DATASOURCE_URL` | PostgreSQL JDBC URL. Docker Compose expects `jdbc:postgresql://postgres:5432/mage`. |
+| `SPRING_DATASOURCE_USERNAME` | Database username. |
+| `SPRING_DATASOURCE_PASSWORD` | Database password. |
+
+Other useful defaults in `.env.example`:
+- `SPRING_APPLICATION_NAME`
+- `SPRING_PROFILES_ACTIVE`
+- `SPRING_JPA_HIBERNATE_DDL_AUTO`
+- `POSTGRES_DB`
+- `POSTGRES_USER`
+- `POSTGRES_PASSWORD`
+
+## Current API Surface
+
+| Route | Auth | Purpose |
+| --- | --- | --- |
+| `GET /health` | Public | Process liveness |
+| `GET /ready` | Public | Application and database readiness |
+| `POST /api/auth/register` | Public | Create a local account |
+| `POST /api/auth/login` | Public | Authenticate a local account |
+| `POST /api/auth/google` | Public | Authenticate with a Google ID token |
+| `POST /api/auth/link/google` | Public | Link Google auth to an existing local account |
+| `POST /api/auth/link/local` | Public | Add local auth to an existing Google-backed account |
+| `GET /api/users/me` | Bearer token | Return the current user profile |
+| `POST /api/tags` | Public | Create a tag |
+| `POST /api/presets` | Bearer token | Create a preset owned by the authenticated user |
+| `GET /api/presets` | Bearer token | List presets, optionally filtered by tag |
+| `POST /api/presets/{id}/tags` | Bearer token | Attach a tag to a preset |
+| `GET /api/presets/{id}` | Public | Fetch a preset by id |
+| `DELETE /api/presets/{id}` | Bearer token | Delete a preset owned by the authenticated user |
+| `GET /api/users/{id}/presets` | Bearer token | List presets for a specific user |
+
+## Repository Layout
 
 ```text
 mage-backend/
 |- docs/
-|  |- architecture.md
-|  |- engineering-standards.md
-|  |- getting-started.md
-|  `- operations.md
 |- src/
 |  |- main/
 |  |  |- java/com/bdmage/mage_backend/
-|  |  |  |- config/
 |  |  |  |- client/
+|  |  |  |- config/
 |  |  |  |- controller/
 |  |  |  |- dto/
 |  |  |  |- exception/
-|  |  |  |- service/
-|  |  |  `- MageBackendApplication.java
+|  |  |  |- model/
+|  |  |  |- repository/
+|  |  |  `- service/
 |  |  `- resources/
-|  |     |- application.properties
 |  |     `- db/migration/
 |  `- test/
-|     `- java/com/bdmage/mage_backend/
-|        |- config/
-|        |- controller/
-|        |- service/
-|        |- support/
-|        `- MageBackendApplicationTests.java
-|- .env.example
 |- CONTRIBUTING.md
 |- docker-compose.yml
 |- Dockerfile
 |- pom.xml
-|- mvnw
-|- mvnw.cmd
 `- README.md
 ```
 
 ## Documentation
 
-- [docs/getting-started.md](docs/getting-started.md): setup, environment variables, local run, tests, migrations, and authentication and account-linking endpoint usage
-- [docs/architecture.md](docs/architecture.md): current codebase structure and the layered design behind health, authentication, explicit account linking, and current-user profile features
-- [docs/engineering-standards.md](docs/engineering-standards.md): coding, API, persistence, testing, logging, security, and collaboration standards
-- [docs/operations.md](docs/operations.md): operational runbook for Docker, health checks, authentication and linking behavior, logs, migrations, and troubleshooting
-- [CONTRIBUTING.md](CONTRIBUTING.md): pull request and contribution workflow
+- [docs/README.md](docs/README.md): documentation index and reading order
+- [docs/getting-started.md](docs/getting-started.md): local setup, configuration, tests, and first verification steps
+- [docs/architecture.md](docs/architecture.md): package layout, request flow, auth model, and persistence model
+- [docs/operations.md](docs/operations.md): runbook, health checks, auth matrix, and troubleshooting
+- [docs/engineering-standards.md](docs/engineering-standards.md): coding, API, testing, and review expectations
+- [CONTRIBUTING.md](CONTRIBUTING.md): branch, PR, and review workflow
 
+## Current Scope
 
+The backend is still early-stage infrastructure. It already has a real authentication model, persistence layer, migrations, and tests, but it does not yet have a broader authorization framework, logout/token revocation, or token expiration.

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,9 +16,3 @@ Use these docs as the source of truth for working in `mage-backend`.
 - [architecture.md](architecture.md): package layout, request flow, auth model, and persistence model
 - [engineering-standards.md](engineering-standards.md): coding, API, persistence, testing, and review expectations
 - [operations.md](operations.md): runbook, route auth matrix, migrations, and troubleshooting
-
-## Supplementary Docs
-
-These are left as-is because they document narrower workflows:
-- [docker-compose-install/README.md](docker-compose-install/README.md)
-- [tag-filter-testing/README.md](tag-filter-testing/README.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,24 @@
+# Backend Docs
+
+Use these docs as the source of truth for working in `mage-backend`.
+
+## Recommended Reading Order
+
+1. [../README.md](../README.md)
+2. [getting-started.md](getting-started.md)
+3. [architecture.md](architecture.md)
+4. [engineering-standards.md](engineering-standards.md)
+5. [operations.md](operations.md)
+
+## Guides
+
+- [getting-started.md](getting-started.md): local setup, environment variables, tests, and first verification steps
+- [architecture.md](architecture.md): package layout, request flow, auth model, and persistence model
+- [engineering-standards.md](engineering-standards.md): coding, API, persistence, testing, and review expectations
+- [operations.md](operations.md): runbook, route auth matrix, migrations, and troubleshooting
+
+## Supplementary Docs
+
+These are left as-is because they document narrower workflows:
+- [docker-compose-install/README.md](docker-compose-install/README.md)
+- [tag-filter-testing/README.md](tag-filter-testing/README.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,318 +1,159 @@
-# Backend Architecture
+# Architecture
 
-Today the backend is responsible for:
+This document describes the backend as it exists today, not an idealized future shape.
 
-- starting the Spring Boot application
-- building and validating the PostgreSQL datasource
-- applying Flyway migrations on startup
-- exposing `/health`, `/ready`, `POST /api/auth/register`, `POST /api/auth/login`, `POST /api/auth/google`, `POST /api/auth/link/google`, `POST /api/auth/link/local`, `GET /api/users/me`, `POST /api/tags`, `POST /api/presets`, `GET /api/presets`, `POST /api/presets/{id}/tags`, `GET /api/presets/{id}`, `DELETE /api/presets/{id}`, and `GET /api/users/{id}/presets`
-- registering local email-and-password accounts through the shared `users` table
-- authenticating local email-and-password accounts through the shared `users` table
-- verifying Google ID tokens server-side against configured Google OAuth client IDs
-- creating or reusing Google-backed user records through the shared `users` table
-- explicitly linking local and Google auth providers after ownership checks
-- issuing bearer tokens after successful local login and Google auth
-- validating bearer tokens in middleware for protected endpoints
-- returning the authenticated user's profile from the shared `users` table
-- hashing local-account passwords through a shared password hashing service
-- exposing shared tag persistence through the `tags` table
-- exposing shared preset persistence through the `presets` table
-- exposing shared preset/tag persistence through the `preset_tags` table
-- proving the runtime wiring with unit and integration tests
+## Responsibilities
 
-The repository does not yet contain product-focused business features, but it already has the basic structure those features should use.
+The service currently owns five main areas:
+- health and readiness
+- authentication and account linking
+- user profile lookup
+- tag management
+- preset storage and tagging
 
-## Current Runtime Components
+It also owns the infrastructure needed to support them:
+- PostgreSQL connectivity
+- Flyway migrations
+- bearer-token validation for protected routes
+- Google ID token verification
 
-### Application Bootstrap
+## High-Level Structure
 
-`MageBackendApplication` is the Spring Boot entry point. It starts the application context and enables component scanning under `com.bdmage.mage_backend`.
+```text
+src/main/java/com/bdmage/mage_backend/
+|- client/
+|- config/
+|- controller/
+|- dto/
+|- exception/
+|- model/
+|- repository/
+`- service/
+```
 
-### Configuration Layer
+Each package has a narrow role:
 
-The configuration package currently contains:
+- `controller`: HTTP entry points and response shaping
+- `service`: application rules and orchestration
+- `repository`: persistence access and query intent
+- `model`: JPA entities and enums
+- `dto`: request and response contracts
+- `config`: Spring wiring, environment binding, and authentication plumbing
+- `client`: external integration boundaries
+- `exception`: custom exceptions and centralized API error mapping
 
-- `DatabaseProperties`
-- `DatabaseConfiguration`
-- `GoogleAuthProperties`
-- `GoogleAuthConfiguration`
-- `PasswordHashingConfiguration`
-- `AuthenticationConfiguration`
+## Request Flow
 
-Together they do six important jobs:
+The normal request path is:
 
-- bind datasource configuration from environment variables
-- validate that required settings exist and use a PostgreSQL JDBC URL
-- create the Hikari `DataSource` and fail startup immediately if PostgreSQL is unreachable
-- bind and validate the allowed Google OAuth client IDs used for server-side token verification
-- expose the shared BCrypt-backed `PasswordEncoder` used by authentication services
-- register the bearer-token authentication middleware used by protected endpoints
+1. a controller accepts the HTTP request
+2. request DTO validation runs at the API boundary
+3. the controller delegates to a service
+4. the service applies business rules and coordinates repositories or clients
+5. repositories read or write PostgreSQL
+6. the controller returns a DTO-backed response
 
-This is intentionally stricter than letting the application start with bad infrastructure settings and fail later on the first request.
+Protected routes add one more step first:
 
-### API Layer
+1. the authentication interceptor validates the bearer token
+2. the authenticated user is attached to request context
+3. controller and service logic run with a trusted server-side identity
 
-The API layer currently consists of five controllers:
+## Controllers
+
+The current API is split across five controllers:
 
 - `HealthController`
 - `AuthController`
-- `TagController`
 - `UserController`
+- `TagController`
 - `PresetController`
 
-Endpoints:
+The route surface is intentionally small and resource-oriented.
 
-- `GET /health`
-- `GET /ready`
-- `POST /api/auth/register`
-- `POST /api/auth/login`
-- `POST /api/auth/google`
-- `POST /api/auth/link/google`
-- `POST /api/auth/link/local`
-- `GET /api/users/me`
-- `POST /api/tags`
-- `POST /api/presets`
-- `GET /api/presets`
-- `POST /api/presets/{id}/tags`
-- `GET /api/presets/{id}`
-- `DELETE /api/presets/{id}`
-- `GET /api/users/{id}/presets`
+## Service Layer
 
-`/health` is a liveness check. It answers the narrow question, "Is the process up?"
+The service layer owns the real behavior:
 
-`/ready` is a readiness check. It answers the more operationally useful question, "Can this instance actually serve traffic right now?"
+- `ReadinessService`: readiness state and database reachability
+- `RegistrationService`: local account creation
+- `LoginService`: local credential verification
+- `GoogleAuthenticationService`: Google token verification and account provisioning
+- `AccountLinkingService`: explicit local/Google linking flows
+- `AuthenticationTokenService`: token creation and validation
+- `UserProfileService`: current-user lookups
+- `TagService`: tag normalization and duplicate checks
+- `PresetService`: preset creation, lookup, deletion, filtering, and tagging
+- `PasswordHashingService`: password hashing and verification
 
-`POST /api/auth/google` accepts a Google ID token, delegates token verification to the service layer, and returns either a created or reused Google-backed user record plus a bearer access token.
+The controller should not contain those decisions.
 
-`POST /api/auth/register` accepts email, password, and display name, delegates registration rules to the service layer, and returns a created local account without exposing password material.
+## Authentication Model
 
-`POST /api/auth/login` accepts email and password, delegates credential verification to the service layer, and returns the authenticated local account plus a bearer access token without exposing password material.
+The backend supports three account states:
+- `LOCAL`
+- `GOOGLE`
+- `LOCAL_GOOGLE`
 
-`POST /api/auth/link/google` accepts a local email/password pair plus a Google ID token and only links the provider after both ownership checks succeed.
+Important rules:
+- local and Google accounts are not auto-linked just because emails match
+- linking requires proof of ownership for both sides
+- successful local login and Google auth issue bearer tokens
+- protected routes trust the authenticated user only after token validation in the interceptor
 
-`POST /api/auth/link/local` accepts a Google ID token plus a new password and only links local auth after the Google-backed account context is verified.
+## Persistence Model
 
-`GET /api/users/me` runs behind authentication middleware. The middleware validates the bearer token, places the authenticated user in request context, and the controller delegates profile lookup to the service layer without exposing password hashes or Google subject identifiers.
+The current data model is centered around these tables:
 
-`POST /api/tags` accepts a tag name, delegates normalization and duplicate-tag checks to the service layer, and stores new tags through the shared `tags` table.
+- `users`
+- `auth_tokens`
+- `tags`
+- `presets`
+- `preset_tags`
 
-`POST /api/presets` runs behind authentication middleware. The middleware validates the bearer token, places the authenticated user in request context, and the controller delegates preset persistence to the service layer so future preset features share one creation path.
+Those are backed by:
+- JPA entities in `model/`
+- Spring Data repositories in `repository/`
+- Flyway migrations in `src/main/resources/db/migration`
 
-`GET /api/presets` runs behind authentication middleware. The middleware validates the bearer token before the controller delegates preset lookup to the service layer. Without a `tag` query parameter it returns all persisted presets, and with `?tag=<name>` it returns only presets linked to that normalized tag name.
+Schema changes are migration-driven. The repo expects PostgreSQL and keeps Hibernate schema mode at `validate` for normal development.
 
-`POST /api/presets/{id}/tags` runs behind authentication middleware. The middleware validates the bearer token, places the authenticated user in request context, and the controller delegates preset/tag association rules to the service layer so tagging and discovery features share one persistence path.
+## External Boundary
 
-`GET /api/presets/{id}` is public. The controller delegates preset lookup to the service layer and returns the preset metadata, scene data, thumbnail reference, and creation timestamp when the preset exists.
+Google sign-in is isolated behind the `GoogleTokenVerifier` interface. The production implementation is `GoogleApiClientTokenVerifier`.
 
-`DELETE /api/presets/{id}` runs behind authentication middleware. The middleware validates the bearer token, places the authenticated user in request context, and the controller delegates owner-only deletion rules to the service layer. The service rejects non-owner deletes with `403 Forbidden` and removes the preset through the shared persistence path, which also clears dependent preset/tag links through database cascading.
+That keeps token verification logic out of controllers and makes the auth service easier to test.
 
-`GET /api/users/{id}/presets` runs behind authentication middleware. The middleware validates the bearer token, places the authenticated user in request context, and the controller delegates preset lookup for the requested user id to the service layer.
+## Error Handling
 
-### Service Layer
+`ApiExceptionHandler` centralizes HTTP error mapping for:
+- validation failures
+- authentication failures
+- account conflicts and link-required cases
+- duplicate tags and duplicate preset-tag links
+- missing presets or tags
+- forbidden preset deletion
 
-The service layer currently consists of:
+The goal is predictable error responses instead of controller-specific ad hoc handling.
 
-- `ReadinessService`
-- `PasswordHashingService`
-- `RegistrationService`
-- `LoginService`
-- `GoogleAuthenticationService`
-- `AccountLinkingService`
-- `AuthenticationTokenService`
-- `TagService`
-- `UserProfileService`
-- `PresetService`
+## Testing Shape
 
-These services combine:
+The test suite mirrors the production layout:
+- controller tests
+- service tests
+- repository integration tests
+- configuration tests
+- migration integration tests
 
-- Spring's `ApplicationAvailability`
-- a live database connection check through the configured `DataSource`
-- BCrypt-backed password hashing for local accounts
-- provider-aware user lookups plus local-account creation rules
-- provider-aware user lookups plus local-account credential verification rules for any account that supports local auth
-- a Google token verifier client
-- provider-aware user lookups plus first-login account creation rules
-- explicit provider-linking rules that require either local credentials or Google ownership before the second provider is attached
-- bearer-token generation plus secure token persistence
-- normalized tag creation plus duplicate-tag checks
-- request-time bearer-token validation for protected routes
-- authenticated-user profile lookup by the middleware-authenticated user identity
-- authenticated-user preset creation plus preset listing, preset filtering by tag, preset/tag association, preset retrieval, owner-only preset deletion, and requested-user preset lookup through the shared `presets` and `preset_tags` tables
+Testcontainers provides PostgreSQL for integration coverage, which means the repo tests against real database behavior instead of mocks alone.
 
-The controller owns HTTP concerns, while the service owns the decision logic for readiness.
+## Current Boundaries and Gaps
 
-The registration service owns local-account creation rules, including duplicate-account checks and password hashing before persistence.
-
-The login service owns local credential verification rules and ensures only accounts with a stored local password can authenticate through the password flow.
-
-The Google auth service owns the backend rules for token validation, account conflict detection, and Google-backed user creation or reuse.
-
-The account linking service owns the explicit linking rules for local-to-Google and Google-to-local flows. It prevents auto-linking based only on matching email addresses and requires an ownership proof for every supported link path.
-
-The tag service owns normalized tag creation rules and duplicate detection before tag persistence.
-
-The preset service owns authenticated preset creation rules, preset list and preset/tag filter lookups, preset/tag association rules, owner-only preset deletion rules, ensures new presets are linked to the authenticated user identity before persistence, centralizes preset lookup by id for retrieval and deletion endpoints, and supports requested-user preset list lookups.
-
-### DTO Layer
-
-The DTO package currently contains:
-
-- `HealthResponse`
-- `ReadinessResponse`
-- `RegistrationRequest`
-- `RegistrationResponse`
-- `LoginRequest`
-- `LoginResponse`
-- `GoogleAuthenticationRequest`
-- `GoogleAuthenticationResponse`
-- `GoogleAccountLinkRequest`
-- `LocalAccountLinkRequest`
-- `AccountLinkResponse`
-- `CreateTagRequest`
-- `TagResponse`
-- `UserProfileResponse`
-- `CreatePresetRequest`
-- `AttachTagToPresetRequest`
-- `PresetResponse`
-- `PresetTagResponse`
-- `ApiErrorResponse`
-
-These are explicit API contracts. Even for small endpoints, the repository prefers returning named response types rather than anonymous maps or loosely shaped JSON.
-
-### Client and Exception Layers
-
-- `GoogleTokenVerifier` is the external-integration boundary used by the auth service
-- `GoogleApiClientTokenVerifier` is the production adapter that uses the Google API Client library
-- `ApiExceptionHandler` centralizes HTTP error responses for validation failures, duplicate-email registration attempts, duplicate-tag creation attempts, duplicate preset/tag attachment attempts, invalid local credentials, invalid authentication tokens, invalid Google tokens, link-required collisions, account conflicts, missing presets, forbidden preset deletions, and missing tags
-
-### Persistence and Database Layer
-
-- PostgreSQL is the only database
-- Flyway owns schema migration
-- Spring Data JPA is available on the classpath
-- `User` maps shared local, Google-backed, and linked multi-provider account data to the `users` table
-- one `users` row may hold a local password hash, a Google subject, or both
-- `UserRepository` supports shared email lookups plus Google subject lookups
-- `AuthenticationToken` maps issued bearer tokens to the `auth_tokens` table
-- `AuthenticationTokenRepository` supports bearer-token hash lookups
-- `Tag` maps normalized tag names to the `tags` table
-- `TagRepository` provides shared access to persisted tags used by tagging and discovery features
-- `Preset` maps preset records, owner references, and JSON scene payloads to the `presets` table
-- `PresetRepository` provides shared access to persisted presets, including optional tag-filter lookups for preset discovery endpoints
-- `PresetTag` maps preset/tag associations to the `preset_tags` table
-- `PresetTagRepository` provides shared access to preset/tag links for tagging and discovery features
-
-At the moment, the persistence layer supports shared account, tag, preset, and preset/tag storage. More domain entities and repositories should follow the same package and layering conventions.
-
-## Folder Structure
-
-```text
-src/
-|- main/
-|  |- java/com/bdmage/mage_backend/
-|  |  |- config/
-|  |  |- client/
-|  |  |- controller/
-|  |  |- dto/
-|  |  |- exception/
-|  |  |- model/
-|  |  |- repository/
-|  |  |- service/
-|  |  `- MageBackendApplication.java
-|  `- resources/
-|     |- application.properties
-|     `- db/migration/
-`- test/
-   `- java/com/bdmage/mage_backend/
-      |- config/
-      |- controller/
-      |- repository/
-      |- service/
-      |- support/
-      `- MageBackendApplicationTests.java
-```
-
-- `config/` is for wiring and infrastructure setup
-- `client/` is for external service verification or transport adapters
-- `controller/` is for HTTP entry points
-- `service/` is for business or application logic
-- `dto/` is for public request and response contracts
-- `exception/` is for centralized API error mapping and custom exceptions
-- `model/` is for JPA entities and domain objects
-- `repository/` is for persistence interfaces and query intent
-- `resources/db/migration/` is for schema evolution
-- `test/support/` is for reusable testing infrastructure
-
-## Request Flow Example
-
-The `/ready` endpoint shows the current end-to-end request path clearly:
-
-1. a client calls `GET /ready`
-2. `HealthController.ready()` handles the request
-3. the controller delegates to `ReadinessService.checkReadiness()`
-4. the service checks Spring's readiness state
-5. the service opens a database connection from the configured `DataSource`
-6. the service validates that connection with `connection.isValid(1)`
-7. the service returns a small internal status object
-8. the controller maps that status into `ReadinessResponse`
-9. the controller returns either `200 OK` or `503 Service Unavailable`
-
-That flow is intentionally simple, but it models the same separation of concerns expected in larger feature work.
-
-## Database and Migration Model
-
-Database behavior in this repository follows these rules:
-
-- the backend expects PostgreSQL
-- datasource settings come from environment variables
-- startup fails fast if the datasource is invalid or unreachable
-- Flyway runs from `src/main/resources/db/migration`
-
-As a result, the expected way to change the schema is straightforward:
-
-1. add a new Flyway migration
-2. start the application or run integration tests
-3. let Flyway apply the new version
-
-## What Is Not Implemented Yet
-
-The codebase does not currently include:
-
-- a general-purpose authorization framework beyond the owner-only preset deletion rule
+The backend is intentionally still narrow. It does not yet include:
+- broader role/permission modeling beyond the current owner-only delete rule
 - logout or token revocation
 - token expiration
+- background jobs
+- broader product-specific business domains beyond auth, presets, and tags
 
-Successful `POST /api/auth/login` and `POST /api/auth/google` requests issue bearer access tokens. Bearer-token authentication currently protects `GET /api/users/me`, `POST /api/presets`, `GET /api/presets`, `POST /api/presets/{id}/tags`, `DELETE /api/presets/{id}`, and `GET /api/users/{id}/presets`, while `GET /api/presets/{id}` remains public.
-
-## Target Architecture as the Backend Grows
-
-As the repository grows, new features should extend the existing layering rather than bypass it.
-
-Recommended package shape:
-
-```text
-com.bdmage.mage_backend
-|- config
-|- controller
-|- service
-|- repository
-|- model
-|- dto
-|- exception
-|- client
-|- job
-`- util
-```
-
-Responsibilities:
-
-- `controller`: HTTP request handling, status codes, request parsing, response mapping
-- `service`: business rules, orchestration, transaction boundaries, cross-entity behavior
-- `repository`: persistence logic and query intent
-- `model`: JPA entities and domain objects
-- `dto`: request and response contracts
-- `exception`: custom exceptions and global error mapping
-- `client`: wrappers for external services
-- `job`: scheduled work, asynchronous tasks, background processing
-
-
+That is acceptable as long as new features continue to extend the existing layers instead of bypassing them.

--- a/docs/engineering-standards.md
+++ b/docs/engineering-standards.md
@@ -1,238 +1,150 @@
 # Engineering Standards
 
-## Purpose
+This document defines the baseline for backend changes in this repository.
 
-This document defines how backend code should be written in this repository. The goal is consistency. A growing backend becomes hard to work on when every feature invents its own rules.
+## Core Principles
 
-## Engineering Philosophy
+Prefer code that is:
+- easy to scan
+- explicit about behavior
+- predictable across packages
+- simple to test
+- easy for another developer to extend
 
-Backend code in this repository should try to be:
+Avoid cleverness that makes the next change harder.
 
-- simple enough to scan quickly
-- explicit enough to debug without guesswork
-- modular enough to change in one place without surprising another
-- consistent across packages and features
-- easy for another developer to pick up and extend
-
-Prefer the design that makes maintenance easier over the design that looks clever in isolation.
-
-## Language and Framework Standards
-
-- Prefer clear names over shortened or abstract names that hide intent.
-- Keep methods small enough that their purpose is obvious from the name and body together.
-- Avoid deep inheritance hierarchies. Composition is usually the better default.
-- Avoid `null` for ordinary control flow. Use explicit contracts.
-
-## Package and Naming Standards
-
-- classes and records use `PascalCase`
-- methods and variables use `camelCase`
-- packages use lowercase
-- controllers end in `Controller`
-- services end in `Service`
-- repositories end in `Repository`
-- configuration classes end in `Configuration`
-- request and response DTOs end in `Request` and `Response`
-- integration tests end in `IntegrationTests`
-
-## Layering Standards
+## Layering
 
 ### Controllers
 
 Controllers should:
-
 - define routes
-- convert HTTP input (JSON, path variables, query parameters) into Java objects.
-- trigger validation to ensure the request data is valid.
-- call services
-- translate service results into HTTP responses
+- validate incoming requests
+- delegate to services
+- shape HTTP responses
+
+Controllers should not own business rules or persistence logic.
 
 ### Services
 
 Services should:
-
-- own use-case logic, meaning the actual things the system does, such as creating a user, processing a payment, or submitting an order
-- coordinate multiple repositories or external clients when needed. For example, creating an order might involve checking inventory, saving the order, and sending a notification
-- define transaction boundaries when data is being written, so related database changes succeed or fail together
-- encode business rules and application decisions, such as whether a user is allowed to perform an action or whether a request should be rejected
+- own use-case logic
+- coordinate repositories and external clients
+- define transaction boundaries when writes span multiple records
+- enforce business and authorization rules
 
 ### Repositories
 
 Repositories should:
+- encapsulate database access
+- expose clear query intent through method names
+- stay focused on persistence, not application logic
 
-- own database reads and writes, meaning they are responsible for fetching data from the database and saving updates back to it
-- hide query details behind clear method names, so callers do not need to understand SQL or query mechanics. For example, findUserByEmail() is clearer than exposing a raw query
-- stay focused on persistence behavior, meaning repositories should only deal with storing and retrieving data, not application logic
+### Configuration
 
-### Configuration Classes
+Configuration classes should:
+- bind environment-driven settings
+- validate required infrastructure assumptions
+- create and wire Spring-managed beans
 
-Configuration should:
+## Naming and Packaging
 
-- create and configure beans, meaning they define the objects Spring should manage and provide to the rest of the application
-- bind configuration properties, such as environment variables or application settings, into strongly typed classes
-- validate infrastructure assumptions, such as ensuring required configuration values exist or that a database connection can be created
+- classes and records: `PascalCase`
+- methods and variables: `camelCase`
+- packages: lowercase
+- controllers: `*Controller`
+- services: `*Service`
+- repositories: `*Repository`
+- DTOs: `*Request` and `*Response`
+- integration tests: `*IntegrationTests`
+
+Keep the package layout aligned with the current repo structure instead of inventing one-off folders.
 
 ## API Standards
 
-### Route Design
+### Routes
 
-- Prefer resource-oriented routes such as `/users` and `/users/{id}`.
-- Avoid verb-heavy route names such as `/getUsers` or `/createUser`.
-- Keep route naming consistent across the codebase.
-- Add route prefixes only when they express a real boundary, such as versioning or an admin surface.
+- prefer resource-oriented routes
+- keep naming consistent across domains
+- avoid verb-heavy endpoint names unless the action is genuinely not resource-like
 
 ### Validation
 
-When request payloads are introduced, validate them at the API boundary.
+- validate request DTOs at the API boundary
+- use Bean Validation annotations for structural rules
+- return consistent error shapes through centralized exception handling
 
-Standard approach:
+### Status Codes
 
-- DTO classes or records define the input contract
-- Jakarta Bean Validation annotations define structural validation rules
-- controllers trigger validation with `@Valid`
-- invalid input is translated by centralized exception handling into a consistent error response
+- `200` for successful reads and updates with a body
+- `201` for successful creation
+- `204` for successful deletes or bodyless success
+- `400` for malformed requests or validation failures
+- `401` for missing or invalid authentication
+- `403` for authenticated but forbidden actions
+- `404` for missing resources
+- `409` for state conflicts
+- `503` for readiness or dependency failures
 
-### Error Handling
+## Persistence Standards
 
-As the API surface grows, use `@ControllerAdvice` to centralize error mapping.
-
-Error responses should be:
-
-- machine-readable
-- consistent across endpoints
-- free of internal stack traces and secret values
-
-Recommended error fields:
-
-- `code`
-- `message`
-- `details` when relevant
-- `path`
-- `timestamp`
-
-### Status Code Guidelines
-
-- `200 OK` for successful reads and updates with a response body
-- `201 Created` for successful resource creation
-- `204 No Content` for successful operations with no response body
-- `400 Bad Request` for malformed requests or validation failures
-- `401 Unauthorized` when authentication is required and missing or invalid
-- `403 Forbidden` when authentication exists but access is not allowed
-- `404 Not Found` when a resource does not exist
-- `409 Conflict` when the request conflicts with current server state
-- `422 Unprocessable Entity` only if the team intentionally distinguishes semantic business-rule failure from basic request validation
-- `503 Service Unavailable` for readiness or downstream dependency failure
-
-## Persistence and Database Standards
-
-- All schema changes go through Flyway migrations.
-- Migration files belong in `src/main/resources/db/migration`.
-- Use `V<version>__<description>.sql`.
-- Treat migrations as append-only once shared with others.
-- Prefer lowercase snake_case for table, column, index, and constraint names.
-- Keep `spring.jpa.hibernate.ddl-auto=validate` for normal development.
-- Use repositories to express query intent instead of scattering persistence logic across services.
-- If a feature introduces multi-step writes, define clear transaction boundaries in the service layer.
-
-### Entity Standards for Future Domain Models
-
-Coming soon: a set of entity design standards for future domain models, including naming conventions, relationship mapping, and best practices for JPA usage.
-
-## Configuration and Secrets
-
-- Configuration should come from environment variables or checked-in non-secret property files.
-- Secrets do not belong in source control.
-- The app should fail fast when required configuration is missing.
-- If a new feature needs configuration, document it in `docs/getting-started.md` and `docs/operations.md`.
-
-## Logging Standards
-
-Logging is part of the backend contract with developers and operators.
-
-- Log meaningful state changes and failures.
-- Do not log secrets, tokens, passwords, or raw sensitive payloads.
-- Prefer logs that help reconstruct what happened without re-running the issue in a debugger.
-- Use structured, consistent message wording when possible.
+- all schema changes go through Flyway
+- migration files belong in `src/main/resources/db/migration`
+- use `V<version>__<description>.sql`
+- treat shared migrations as append-only
+- keep Hibernate schema mode at `validate` for standard development
+- keep persistence logic in repositories and service transaction boundaries
 
 ## Security Standards
 
-Security is not fully implemented in this repository yet, but the standards should be clear now.
-
-- Authenticate before trusting client identity.
-- Enforce authorization close to business logic, not only at the route declaration.
-- Validate all client input.
-- Never trust ownership claims from the client without server-side checks.
-- Hash passwords with established libraries and never invent custom crypto.
-- Keep secrets in environment-based configuration or a proper secret manager.
+- never trust client-supplied identity without server-side verification
+- keep authorization checks close to the business rule they protect
+- do not log secrets, passwords, tokens, or raw sensitive payloads
+- use established hashing libraries for password handling
+- keep secrets in environment-driven configuration
 
 ## External Integration Standards
 
-If external APIs or services are added:
-
-- isolate them behind `client` classes or modules
-- define clear request and response boundaries
-- set timeouts explicitly
-- handle retries deliberately, not accidentally
-- make idempotency expectations explicit for write operations
-- separate transport failures from domain failures in error handling
-
-## Background Job Standards
-
-If any jobs or scheduled tasks are added:
-
-- place them under a dedicated `job` package
-- make them idempotent where possible
-- avoid hidden scheduling logic inside controllers or repositories
-- log job start, success, failure, and retry behavior clearly
-- separate job orchestration from the domain logic it invokes
+When adding external dependencies:
+- isolate them behind client interfaces or adapters
+- make timeout and retry behavior explicit
+- separate transport failures from domain failures
+- make write idempotency expectations clear
 
 ## Testing Standards
 
-### Unit Tests
+Every behavioral change should add or update tests.
 
-Use unit tests for:
+Use:
+- unit tests for service logic, configuration, and isolated controller behavior
+- integration tests for HTTP behavior, persistence, and full application wiring
+- Testcontainers for PostgreSQL-backed integration coverage
 
-- service logic
-- controller behavior that can be isolated
-- configuration validation
-- small utility code
-
-### Integration Tests
-
-Use integration tests for:
-
-- Spring Boot application wiring
-- HTTP behavior with real controller registration
-- Flyway startup behavior
-- real PostgreSQL interactions
-
-Use Testcontainers for database-backed integration tests. Do not assume every contributor has a manually provisioned local database.
-
-### Test Naming and Placement
-
-- mirror the production package structure under `src/test/java`
-- use `*Tests` for unit-scope tests
-- use `*IntegrationTests` for Spring or database integration tests
-- give test methods names that explain behavior, not implementation mechanics
-
-### Testing Expectations
-
-- every behavior change should add or update tests
-- bug fixes should include a test that would have caught the bug
-- schema changes should be exercised against Flyway-managed startup
+Good tests should explain behavior, not implementation mechanics.
 
 ## Documentation Standards
 
-- Public APIs should be documented through explicit DTOs and clear route naming.
-- Developer workflow changes should update `docs/getting-started.md` or `docs/operations.md` as appropriate.
-- Architecture changes should update `docs/architecture.md`.
-- Team-process changes should update `CONTRIBUTING.md`.
+Update documentation when you change:
+- setup or configuration
+- operational behavior
+- architecture or package boundaries
+- contribution workflow
 
-## Git and Review Standards
+Relevant files:
+- `README.md`
+- `docs/getting-started.md`
+- `docs/architecture.md`
+- `docs/operations.md`
+- `CONTRIBUTING.md`
 
-- Keep branches focused.
-- Use commit messages in imperative mood.
-- Keep pull requests reviewable.
-- Separate refactors from behavior changes when practical.
-- Explain migration, API, or configuration impact in the PR description.
-- Review for correctness, architecture, maintainability, and missing tests before style nitpicking.
+## Review Standards
+
+Keep pull requests focused and easy to review.
+
+A good PR should make clear:
+- what changed
+- why it changed
+- how it was tested
+- whether it affects API shape, configuration, or schema
+
+Review for correctness, architecture, risk, and missing tests before style nits.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,277 +1,144 @@
 # Getting Started
 
-## Purpose
-
-This guide provides the fastest path from cloning the repository to running the MAGE backend locally. It assumes contributors are comfortable with developer tooling but may be new to this repository's setup and conventions.
-
-The local development environment is fully containerized using Docker Compose. This keeps setup consistent across machines and avoids installing PostgreSQL or managing runtime configuration manually.
+This guide is the shortest path from clone to a working local backend.
 
 ## Prerequisites
 
-| Tool                            | Required version        | Why it matters                                                |
-| ------------------------------- | ----------------------- | ------------------------------------------------------------- |
-| Git                             | current stable          | clone the repository and manage branches                      |
-| Docker Desktop or Docker Engine | current stable          | run the backend and PostgreSQL locally                        |
-| Java                            | 21                      | required by the build and test runtime                        |
-| Maven                           | not required separately | use the Maven wrapper included in the repository              |
-| IDE                             | optional                | IntelliJ IDEA or VS Code with Java support are common choices |
+- Git
+- Docker Desktop or a local Docker Engine
+- Java 21
+- an IDE with Java support if you want local editing/debugging
 
-Docker must also be running when executing the integration test suite because Testcontainers is used.
+You do not need a separate Maven install. Use the wrapper in the repo.
 
-## Clone the Repository
+## First Run
 
-    git clone https://github.com/B2MAGE/mage-backend.git
-    cd mage-backend
-
-The first Maven wrapper command downloads project dependencies automatically.
-
-## Configure Environment Variables
-
-Copy the example environment file.
+1. Clone the repository and enter the project directory.
+2. Copy the example environment file.
+3. Start the local stack with Docker Compose.
 
 Windows PowerShell:
 
-    Copy-Item .env.example .env
+```powershell
+Copy-Item .env.example .env
+docker compose up --build
+```
 
 macOS/Linux:
 
-    cp .env.example .env
+```bash
+cp .env.example .env
+docker compose up --build
+```
 
-The `.env` file provides configuration used by Docker Compose.
+This starts:
+- `postgres`: PostgreSQL 16
+- `backend`: the Spring Boot service from this repo
 
-Important details:
+## Environment Variables
 
-- the backend connects to PostgreSQL using the hostname `postgres`
-- this hostname works because both containers run in the same Docker network
-- `MAGE_AUTH_GOOGLE_CLIENT_IDS` must be set to the Google OAuth client ID used by the frontend
-- multiple Google client IDs can be provided as a comma-separated list if more than one frontend must be trusted
+The Docker workflow uses `.env`.
 
-Avoid changing these values unless you understand the container network configuration.
+| Variable | Required | Notes |
+| --- | --- | --- |
+| `SERVER_PORT` | Yes | Defaults to `8080`. |
+| `MAGE_AUTH_GOOGLE_CLIENT_IDS` | Yes | Must include the frontend Google OAuth client ID used for ID token sign-in. |
+| `SPRING_DATASOURCE_URL` | Yes | For Docker Compose, use `jdbc:postgresql://postgres:5432/mage`. |
+| `SPRING_DATASOURCE_USERNAME` | Yes | Database username. |
+| `SPRING_DATASOURCE_PASSWORD` | Yes | Database password. |
+| `SPRING_JPA_HIBERNATE_DDL_AUTO` | No | Local default is `validate`. Keep it that way unless you have a specific reason to change it. |
 
-## Start the Backend
+`.env.example` is set up for the containerized workflow. If you change the datasource host, make sure it still matches the way you are running the app.
 
-Run the full development stack:
+## Verify the Service
 
-    docker compose up --build
+Once startup completes, check:
 
-This command will:
-
-- build the backend image
-- start the PostgreSQL container
-- wait for the database health check
-- start the backend service
-- stream logs to your terminal
-
-## Verify the Application
-
-Once the backend is running, open the following endpoints:
-
-- http://localhost:8080/health
-- http://localhost:8080/ready
-- POST http://localhost:8080/api/auth/register
-- POST http://localhost:8080/api/auth/login
-- POST http://localhost:8080/api/auth/google
-- POST http://localhost:8080/api/auth/link/google
-- POST http://localhost:8080/api/auth/link/local
-- GET http://localhost:8080/api/users/me
-- POST http://localhost:8080/api/tags
-- POST http://localhost:8080/api/presets
-- GET http://localhost:8080/api/presets
-- POST http://localhost:8080/api/presets/{presetId}/tags
-- GET http://localhost:8080/api/presets/{presetId}
-- DELETE http://localhost:8080/api/presets/{presetId}
-- GET http://localhost:8080/api/users/{id}/presets
+- `GET http://localhost:8080/health`
+- `GET http://localhost:8080/ready`
 
 Expected responses:
+- `/health`: `200 OK`
+- `/ready`: `200 OK` when PostgreSQL is reachable, `503` while the app is still coming up or the database is unavailable
 
-- `/health` returns `200 OK` with `{"status":"UP"}`
-- `/ready` returns `200 OK` with `{"status":"UP","database":"UP"}` when PostgreSQL is reachable
-- `POST /api/auth/register` returns `201 Created` for a new local account and never returns the raw password or stored password hash
-- `POST /api/auth/register` returns `409 Conflict` with `ACCOUNT_LINK_REQUIRED` when the email already belongs to a Google-backed account and local auth must be linked explicitly
-- `POST /api/auth/login` returns `200 OK` when a local account's credentials are valid and includes an `accessToken` for protected endpoints without exposing the raw password or stored password hash
-- `POST /api/auth/google` returns either `201 Created` or `200 OK` and includes an `accessToken` for protected endpoints
-- `POST /api/auth/google` returns `409 Conflict` with `ACCOUNT_LINK_REQUIRED` when a local-only account already exists for the verified email
-- `POST /api/auth/link/google` returns `200 OK` when both the local credentials and Google token prove ownership of the same email and the second provider is linked
-- `POST /api/auth/link/local` returns `200 OK` when a valid Google-backed account context is used to attach local password authentication
-- `GET /api/users/me` returns `200 OK` with the authenticated user's profile when the request includes `Authorization: Bearer <accessToken>`
-- `POST /api/tags` returns `201 Created` with the persisted normalized tag fields
-- `POST /api/presets` returns `201 Created` with the created preset fields when the request includes `Authorization: Bearer <accessToken>`
-- `GET /api/presets` returns `200 OK` with an array of presets when the request includes `Authorization: Bearer <accessToken>`, and `GET /api/presets?tag=ambient` returns only presets linked to that tag or an empty array when none match
-- `POST /api/presets/{presetId}/tags` returns `201 Created` with the preset/tag association fields when the request includes `Authorization: Bearer <accessToken>` and both records exist
-- `GET /api/presets/{presetId}` returns `200 OK` with the preset metadata, scene data, thumbnail reference, and creation timestamp when the preset exists, even without an `Authorization` header
-- `DELETE /api/presets/{presetId}` returns `204 No Content` when the request includes `Authorization: Bearer <accessToken>` and the authenticated user owns the preset, `403 Forbidden` when a different authenticated user tries to delete it, and `404 Not Found` when the preset does not exist
-- `GET /api/users/{id}/presets` returns `200 OK` with an array of presets for the requested user when the request includes `Authorization: Bearer <accessToken>`
+Useful follow-up checks:
+- `POST /api/auth/register`
+- `POST /api/auth/login`
+- `GET /api/users/me` with a bearer token
+- `POST /api/presets`
+- `GET /api/presets/{id}`
 
-If `/ready` returns `503`, the application process is running but not yet ready to serve traffic.
-
-To exercise the local registration endpoint:
-
-    curl -X POST http://localhost:8080/api/auth/register \
-      -H "Content-Type: application/json" \
-      -d '{"email":"user@example.com","password":"example-password","displayName":"Example User"}'
-
-To exercise the local login endpoint:
-
-    curl -X POST http://localhost:8080/api/auth/login \
-      -H "Content-Type: application/json" \
-      -d '{"email":"user@example.com","password":"example-password"}'
-
-Use the `accessToken` from the login response or Google auth response when calling protected endpoints.
-
-    curl -X POST http://localhost:8080/api/tags \
-      -H "Content-Type: application/json" \
-      -d '{"name":"Ambient"}'
-
-    curl http://localhost:8080/api/users/me \
-      -H "Authorization: Bearer <access-token>"
-
-    curl -X POST http://localhost:8080/api/presets \
-      -H "Authorization: Bearer <access-token>" \
-      -H "Content-Type: application/json" \
-      -d '{"name":"Aurora Drift","sceneData":{"visualizer":{"shader":"nebula"}},"thumbnailRef":"thumbnails/preset-1.png"}'
-
-    curl http://localhost:8080/api/presets?tag=ambient \
-      -H "Authorization: Bearer <access-token>"
-
-    curl -X POST http://localhost:8080/api/presets/<preset-id>/tags \
-      -H "Authorization: Bearer <access-token>" \
-      -H "Content-Type: application/json" \
-      -d '{"tagId":<tag-id>}'
-
-    curl http://localhost:8080/api/presets/<preset-id>
-
-    curl -X DELETE http://localhost:8080/api/presets/<preset-id> \
-      -H "Authorization: Bearer <access-token>"
-
-    curl http://localhost:8080/api/users/<user-id>/presets \
-      -H "Authorization: Bearer <access-token>"
-
-To exercise the Google auth endpoint, send a Google ID token issued for one of the configured client IDs:
-
-    curl -X POST http://localhost:8080/api/auth/google \
-      -H "Content-Type: application/json" \
-      -d '{"idToken":"<google-id-token>"}'
-
-To explicitly link Google to an existing local account, provide local credentials plus a valid Google ID token for the same email address:
-
-    curl -X POST http://localhost:8080/api/auth/link/google \
-      -H "Content-Type: application/json" \
-      -d '{"email":"user@example.com","password":"example-password","idToken":"<google-id-token>"}'
-
-To add local email-and-password authentication to an existing Google-backed account, provide the Google ID token plus the new local password:
-
-    curl -X POST http://localhost:8080/api/auth/link/local \
-      -H "Content-Type: application/json" \
-      -d '{"idToken":"<google-id-token>","password":"example-password"}'
+For endpoint behavior and auth requirements, use [operations.md](operations.md).
 
 ## Running Tests
 
-Run the full test suite using the Maven wrapper.
-
 Windows PowerShell:
 
-    .\mvnw.cmd test
+```powershell
+.\mvnw.cmd test
+```
 
 macOS/Linux:
 
-    ./mvnw test
+```bash
+./mvnw test
+```
 
-The test suite includes:
+The suite includes:
+- unit tests for controllers, services, and configuration
+- integration tests for HTTP behavior and persistence
+- Flyway migration coverage
+- PostgreSQL-backed tests through Testcontainers
 
-- unit tests for controllers, services, and configuration logic
-- Spring Boot integration tests
-- PostgreSQL-backed integration tests using Testcontainers
-- Flyway migration verification
-
-Docker must be running because Testcontainers starts PostgreSQL automatically during integration tests.
+Docker must be running for the integration suite.
 
 ## Database Migrations
 
-Flyway migrations run automatically during application startup.
+Flyway runs automatically at startup.
 
-Schema changes must follow these rules:
+Migration rules:
+- add new files under `src/main/resources/db/migration`
+- use `V<version>__<description>.sql`
+- treat shared migrations as append-only
 
-- add migration files under `src/main/resources/db/migration`
-- use filenames in the format `V<version>__<description>.sql`
-- treat migrations as append-only
-- do not modify migrations that have already been applied in shared environments
+If local schema state gets messy, the quickest reset is:
 
-To test migrations against a clean database:
+```bash
+docker compose down -v
+docker compose up --build
+```
 
-    docker compose down -v
-    docker compose up --build
+## Common Local Issues
 
-This resets the PostgreSQL volume and re-applies all migrations.
+### `/ready` returns `503`
 
-## Common Setup Problems
+The process is up, but the app is not ready to serve traffic yet. Check:
+- PostgreSQL container health
+- backend logs
+- datasource values in `.env`
 
-### Backend fails with a datasource configuration error
+### Docker startup fails
 
-Check that:
+Check:
+- Docker is running
+- ports `5432` and `8080` are available
 
-- the `.env` file exists
-- Docker Compose is loading environment variables correctly
-- PostgreSQL container is running
+### Google auth fails immediately
 
-### `/ready` returns `503 Service Unavailable`
+Check:
+- `MAGE_AUTH_GOOGLE_CLIENT_IDS` is set
+- the client ID matches the frontend that issued the ID token
 
-This usually means PostgreSQL is not reachable yet. Check container health and backend logs.
+### Tests fail before assertions run
 
-### Docker commands fail
+The usual cause is that Docker is unavailable, so Testcontainers cannot start PostgreSQL.
 
-Make sure Docker Desktop or your local Docker daemon is running.
+## Suggested Reading Order
 
-### Port `5432` or `8080` is already in use
+If you are new to the backend:
 
-Stop the conflicting process or change the port mapping in `docker-compose.yml`.
-
-### Database state appears inconsistent
-
-Reset the Docker volume:
-
-    docker compose down -v
-    docker compose up --build
-
-### First run is slow
-
-On a fresh machine, Docker images and Maven dependencies must be downloaded. Subsequent runs will be significantly faster.
-
-## Suggested First-Day Workflow
-
-If you are new to the repository, this sequence builds the fastest mental model of the system:
-
-1. clone the repository
-2. run `docker compose up --build`
-3. verify `/health` and `/ready`
-4. run the test suite
-5. read `architecture.md`
-6. read `engineering-standards.md`
-7. trace the `/ready` endpoint from controller to service to datasource
-8. trace `POST /api/auth/register` from controller to service to repository and password hashing
-9. trace `POST /api/auth/login` from controller to service to repository and password hashing
-10. trace `POST /api/auth/google` from controller to service to verifier to repository
-11. trace `POST /api/auth/link/google` through the explicit local-credentials-plus-Google-token ownership checks
-12. trace `POST /api/auth/link/local` through the verified Google account context and password-link path
-13. trace `GET /api/users/me` from authentication middleware to controller to service to repository
-14. trace `POST /api/tags` from controller to service to repository
-15. trace `POST /api/presets` from authentication middleware to controller to service to repository
-16. trace `GET /api/presets` from authentication middleware to controller to service to repository, including the optional `tag` query parameter path
-17. trace `POST /api/presets/{id}/tags` from authentication middleware to controller to service to repository
-18. trace public `GET /api/presets/{id}` from the controller to the service to the repository
-19. trace `DELETE /api/presets/{id}` from authentication middleware to controller to service, including the owner-only authorization check
-20. trace `GET /api/users/{id}/presets` from authentication middleware to controller to service to repository
-
-## Expected Change Workflow
-
-When making backend changes, follow this order:
-
-1. understand the current behavior
-2. determine which layer owns the change
-3. implement the change
-4. add or update tests
-5. add Flyway migrations if the schema changes
-6. update documentation if developer or operational workflows change
-
-Also check out: [architecture.md](architecture.md), [engineering-standards.md](engineering-standards.md), and [operations.md](operations.md)
-
-
+1. Read [README.md](../README.md)
+2. Run the stack locally
+3. Read [architecture.md](architecture.md)
+4. Read [engineering-standards.md](engineering-standards.md)
+5. Trace one request end to end, such as `POST /api/auth/register` or `POST /api/presets`

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,456 +1,25 @@
 # Operations
 
-## Purpose
+This document is the practical runbook for starting, checking, and troubleshooting the backend.
 
-This document focuses on what a developer or operator needs to know to start the service, verify it, inspect failures, reset local state, and understand the repository's current operational behavior.
+## Local Runtime Model
 
-## Current Operational Model
-
-The local stack currently contains two services:
-
-- `backend`: the Spring Boot application built from this repository
-- `postgres`: a PostgreSQL 16 container used for local development
+The standard local stack has two services:
+- `postgres`
+- `backend`
 
 Operationally important behavior:
+- PostgreSQL exposes a health check with `pg_isready`
+- Docker Compose waits for PostgreSQL before starting the backend
+- the backend validates datasource configuration at startup
+- Flyway runs automatically on startup
+- bearer-token validation protects the authenticated routes
 
-- PostgreSQL exposes a health check through `pg_isready`
-- the backend waits for PostgreSQL to become healthy in Docker Compose
-- the backend validates datasource settings at startup
-- the backend opens a real database connection during startup and fails if the connection cannot be made
-- Flyway applies migrations automatically on startup
-- local passwords are hashed and verified with BCrypt through the shared password hashing service
-- Google ID tokens are verified server-side against `MAGE_AUTH_GOOGLE_CLIENT_IDS`
-- successful `POST /api/auth/login` and `POST /api/auth/google` requests issue bearer access tokens
-- local and Google auth providers can be linked explicitly, but never auto-linked only because emails match
-- authentication middleware validates bearer tokens for protected `/api/users/**` endpoints and protected preset routes, while `GET /api/presets/{id}` remains public
-
-## Local Startup Runbook
+## Start the Stack
 
 ```bash
 docker compose up --build
 ```
-
-Use this when:
-
-- validating Docker-based local behavior
-- testing migration behavior against a clean containerized stack
-
-Before using `POST /api/auth/google`, replace the placeholder value in `.env` for `MAGE_AUTH_GOOGLE_CLIENT_IDS` with the Google OAuth client ID used by the frontend.
-
-## Health Checks and Auth Endpoints
-
-The backend currently exposes fifteen operational endpoints:
-
-- `GET /health`
-- `GET /ready`
-- `POST /api/auth/register`
-- `POST /api/auth/login`
-- `POST /api/auth/google`
-- `POST /api/auth/link/google`
-- `POST /api/auth/link/local`
-- `GET /api/users/me`
-- `POST /api/tags`
-- `POST /api/presets`
-- `GET /api/presets`
-- `POST /api/presets/{id}/tags`
-- `GET /api/presets/{id}`
-- `DELETE /api/presets/{id}`
-- `GET /api/users/{id}/presets`
-
-### `/health`
-
-Purpose:
-
-- liveness check
-
-Meaning:
-
-- the application process is up and can respond to a minimal HTTP request
-
-Expected response:
-
-```json
-{ "status": "UP" }
-```
-
-### `/ready`
-
-Purpose:
-
-- readiness check
-
-Meaning:
-
-- the application is accepting traffic
-- PostgreSQL is reachable through the configured datasource
-
-Expected ready response:
-
-```json
-{ "status": "UP", "database": "UP" }
-```
-
-Expected not-ready behavior:
-
-- HTTP `503 Service Unavailable`
-- response body shows the application and database status
-
-### `POST /api/auth/register`
-
-Purpose:
-
-- create a local email-and-password account
-
-Request:
-
-```json
-{
-  "email": "user@example.com",
-  "password": "example-password",
-  "displayName": "Example User"
-}
-```
-
-Success behavior:
-
-- HTTP `201 Created` for a newly created local account
-- response includes the new user identity fields and auth provider
-- response never includes the raw password or stored password hash
-
-Failure behavior:
-
-- HTTP `400 Bad Request` for malformed JSON or request validation failures
-- HTTP `409 Conflict` with `EMAIL_ALREADY_REGISTERED` when local authentication is already configured for that email
-- HTTP `409 Conflict` with `ACCOUNT_LINK_REQUIRED` when the email belongs to a Google-backed account and explicit linking is required
-
-### `POST /api/auth/login`
-
-Purpose:
-
-- authenticate an existing local email-and-password account
-
-Request:
-
-```json
-{
-  "email": "user@example.com",
-  "password": "example-password"
-}
-```
-
-Success behavior:
-
-- HTTP `200 OK` for a valid local account credential pair
-- response includes the authenticated user identity fields, auth provider, and an `accessToken`
-- response never includes the raw password or stored password hash
-
-Failure behavior:
-
-- HTTP `400 Bad Request` for malformed JSON or request validation failures
-- HTTP `401 Unauthorized` when the credentials do not match a local account
-
-### `POST /api/auth/google`
-
-Purpose:
-
-- authenticate a frontend-supplied Google ID token
-- create a Google-backed user on first successful authentication
-- reuse that same Google-backed user on later authentications
-
-Request:
-
-```json
-{ "idToken": "<google-id-token>" }
-```
-
-Success behavior:
-
-- HTTP `201 Created` when the backend creates a new Google-backed user
-- HTTP `200 OK` when the backend reuses an existing Google-backed user
-- both success responses include an `accessToken`
-
-Failure behavior:
-
-- HTTP `400 Bad Request` for malformed JSON or blank `idToken`
-- HTTP `401 Unauthorized` for invalid, expired, or unverified Google identities
-- HTTP `409 Conflict` with `ACCOUNT_LINK_REQUIRED` when a local-only account already exists for the verified email
-- HTTP `409 Conflict` with `ACCOUNT_CONFLICT` when a different Google identity already owns that email in the backend
-
-### `POST /api/auth/link/google`
-
-Purpose:
-
-- explicitly link Google authentication to an existing local account
-- require both local-credential ownership and Google-token ownership before the link is persisted
-
-Request:
-
-```json
-{
-  "email": "user@example.com",
-  "password": "example-password",
-  "idToken": "<google-id-token>"
-}
-```
-
-Success behavior:
-
-- HTTP `200 OK` when the Google provider is linked to the existing account
-- response includes the user identity fields, `LOCAL_GOOGLE` auth provider state, and a `linked` flag
-
-Failure behavior:
-
-- HTTP `400 Bad Request` for malformed JSON or request validation failures
-- HTTP `401 Unauthorized` with `INVALID_LOCAL_CREDENTIALS` when the supplied local email/password pair is invalid
-- HTTP `409 Conflict` with `ACCOUNT_CONFLICT` when the Google token email does not match the local email or the Google identity already belongs to another account
-
-### `POST /api/auth/link/local`
-
-Purpose:
-
-- explicitly add local email-and-password authentication to an existing Google-backed account
-- require Google-token ownership before a password hash is attached to the user record
-
-Request:
-
-```json
-{
-  "idToken": "<google-id-token>",
-  "password": "example-password"
-}
-```
-
-Success behavior:
-
-- HTTP `200 OK` when local authentication is linked to the Google-backed account
-- response includes the user identity fields, `LOCAL_GOOGLE` auth provider state, and a `linked` flag
-
-Failure behavior:
-
-- HTTP `400 Bad Request` for malformed JSON or request validation failures
-- HTTP `401 Unauthorized` for invalid, expired, or unverified Google identities
-- HTTP `409 Conflict` with `ACCOUNT_LINK_REQUIRED` when no Google-backed account exists yet for that Google identity
-- HTTP `409 Conflict` with `ACCOUNT_CONFLICT` when the link request collides with an incompatible existing account state
-
-### `GET /api/users/me`
-
-Purpose:
-
-- return the profile of the authenticated user
-
-Request notes:
-
-- requires an `Authorization: Bearer <accessToken>` header using a token issued by `POST /api/auth/login` or `POST /api/auth/google`
-
-Success behavior:
-
-- HTTP `200 OK` for a valid authenticated bearer token
-- response includes the authenticated user's identity fields, auth provider, and creation timestamp
-- response never includes the raw password, stored password hash, or Google subject
-
-Failure behavior:
-
-- HTTP `401 Unauthorized` when the request is missing a bearer token, uses an invalid token, or the token points to a user record that no longer exists
-
-### `POST /api/tags`
-
-Purpose:
-
-- create a new tag
-
-Request:
-
-```json
-{
-  "name": "ambient"
-}
-```
-
-Success behavior:
-
-- HTTP `201 Created` for a valid tag creation request
-- response includes the persisted tag id and normalized tag name
-
-Failure behavior:
-
-- HTTP `400 Bad Request` for malformed JSON or request validation failures
-- HTTP `409 Conflict` when the supplied tag name already exists after normalization
-
-### `POST /api/presets`
-
-Purpose:
-
-- create a new preset owned by the authenticated user
-
-Request notes:
-
-- requires an `Authorization: Bearer <accessToken>` header using a token issued by `POST /api/auth/login` or `POST /api/auth/google`
-
-Request:
-
-```json
-{
-  "name": "Aurora Drift",
-  "sceneData": {
-    "visualizer": {
-      "shader": "nebula"
-    }
-  },
-  "thumbnailRef": "thumbnails/preset-1.png"
-}
-```
-
-Success behavior:
-
-- HTTP `201 Created` for a valid authenticated request
-- response includes the created preset id, owner user id, preset metadata, scene data, and creation timestamp
-
-Failure behavior:
-
-- HTTP `400 Bad Request` for malformed JSON or request validation failures
-- HTTP `401 Unauthorized` when the request is missing a bearer token, uses an invalid token, or the token points to a user record that no longer exists
-
-### `GET /api/presets`
-
-Purpose:
-
-- return persisted presets
-- optionally filter presets by tag using `?tag=<name>`
-
-Request notes:
-
-- requires an `Authorization: Bearer <accessToken>` header using a token issued by `POST /api/auth/login` or `POST /api/auth/google`
-- when `tag` is omitted, the endpoint returns all persisted presets
-- when `tag` is provided, the backend trims and normalizes it before looking up linked presets
-
-Success behavior:
-
-- HTTP `200 OK` for a valid authenticated request
-- response includes an array of preset records
-- `GET /api/presets?tag=ambient` returns only presets linked to that tag
-- returns an empty array when no presets match the supplied tag
-
-Failure behavior:
-
-- HTTP `401 Unauthorized` when the request is missing a bearer token, uses an invalid token, or the token points to a user record that no longer exists
-
-### `POST /api/presets/{id}/tags`
-
-Purpose:
-
-- attach an existing tag to an existing preset
-
-Request notes:
-
-- requires an `Authorization: Bearer <accessToken>` header using a token issued by `POST /api/auth/login` or `POST /api/auth/google`
-
-Request:
-
-```json
-{
-  "tagId": 15
-}
-```
-
-Success behavior:
-
-- HTTP `201 Created` for a valid authenticated request
-- response includes the linked preset id and tag id
-
-Failure behavior:
-
-- HTTP `400 Bad Request` for malformed JSON or request validation failures
-- HTTP `401 Unauthorized` when the request is missing a bearer token, uses an invalid token, or the token points to a user record that no longer exists
-- HTTP `404 Not Found` when either the preset or tag does not exist
-- HTTP `409 Conflict` when the preset already has that tag attached
-
-### `GET /api/presets/{id}`
-
-Purpose:
-
-- return a persisted preset by id
-
-Request notes:
-
-- does not require authentication
-- ignores missing bearer tokens and returns preset data when the preset exists
-
-Success behavior:
-
-- HTTP `200 OK` when the preset exists
-- response includes the preset id, owner user id, preset metadata, scene data, thumbnail reference, and creation timestamp
-
-Failure behavior:
-
-- HTTP `404 Not Found` when no preset exists for the supplied id
-
-### `DELETE /api/presets/{id}`
-
-Purpose:
-
-- delete a persisted preset owned by the authenticated user
-
-Request notes:
-
-- requires an `Authorization: Bearer <accessToken>` header using a token issued by `POST /api/auth/login` or `POST /api/auth/google`
-
-Success behavior:
-
-- HTTP `204 No Content` for a valid authenticated request when the preset exists and the authenticated user owns it
-- deleting a preset also removes dependent preset/tag links through cascading database constraints
-
-Failure behavior:
-
-- HTTP `401 Unauthorized` when the request is missing a bearer token, uses an invalid token, or the token points to a user record that no longer exists
-- HTTP `403 Forbidden` when the request is authenticated successfully but the preset belongs to a different user
-- HTTP `404 Not Found` when no preset exists for the supplied id
-
-### `GET /api/users/{id}/presets`
-
-Purpose:
-
-- return presets owned by the requested user
-
-Request notes:
-
-- requires an `Authorization: Bearer <accessToken>` header using a token issued by `POST /api/auth/login` or `POST /api/auth/google`
-
-Success behavior:
-
-- HTTP `200 OK` for a valid authenticated request
-- response includes an array of preset records for the requested user id
-- returns an empty array when the requested user has no presets
-
-Failure behavior:
-
-- HTTP `401 Unauthorized` when the request is missing a bearer token, uses an invalid token, or the token points to a user record that no longer exists
-
-## Operational Verification Checklist
-
-After startup, verify these items in order:
-
-1. `docker compose ps` shows healthy PostgreSQL if you are using Docker Compose
-2. backend logs show Hikari datasource startup
-3. backend logs show Flyway applying or validating migrations
-4. `curl http://localhost:8080/health` returns `200`
-5. `curl http://localhost:8080/ready` returns `200`
-6. `POST /api/auth/register` succeeds for a new local email address
-7. `POST /api/auth/login` succeeds for that local account and returns an `accessToken`
-8. `GET /api/users/me` succeeds when called with `Authorization: Bearer <accessToken>`
-9. `POST /api/auth/google` succeeds with a valid Google ID token issued for a configured client ID and returns an `accessToken`
-10. `POST /api/auth/link/google` succeeds when both the local credentials and Google token prove ownership of the same email
-11. `POST /api/auth/link/local` succeeds for an existing Google-backed account with a valid Google ID token
-12. `POST /api/tags` succeeds with a valid tag payload and returns the normalized tag record
-13. `POST /api/presets` succeeds when called with `Authorization: Bearer <accessToken>` and a valid preset payload
-14. `GET /api/presets` succeeds when called with `Authorization: Bearer <accessToken>` and returns either all presets, only presets matching `?tag=<name>`, or an empty array when no presets match
-15. `POST /api/presets/{id}/tags` succeeds when called with `Authorization: Bearer <accessToken>`, an existing preset id, and an existing tag id
-16. `GET /api/presets/{id}` succeeds for public requests and returns the preset when the id exists
-17. `DELETE /api/presets/{id}` succeeds when called with `Authorization: Bearer <accessToken>` by the preset owner and returns `204 No Content`
-18. `GET /api/users/{id}/presets` succeeds when called with `Authorization: Bearer <accessToken>` and returns either preset records or an empty array
-
-If step 5 fails with `503`, the app is running but not ready to serve traffic.
-
-## Logs and What to Look For
 
 Useful log commands:
 
@@ -460,246 +29,125 @@ docker compose logs -f backend
 docker compose logs -f postgres
 ```
 
-During a healthy startup, expect to see:
+## Health Checks
 
-- backend startup on port `8080`
-- Hikari datasource creation
-- successful PostgreSQL connection
-- Flyway validation and migration output
-- no Google tokens, passwords, or raw auth payloads in logs
+### `GET /health`
 
-If the backend fails early, focus on the first infrastructure error rather than the final stack trace tail.
+Use this as a liveness check.
+
+Healthy response:
+
+```json
+{ "status": "UP" }
+```
+
+### `GET /ready`
+
+Use this as a readiness check.
+
+Healthy response:
+
+```json
+{ "status": "UP", "database": "UP" }
+```
+
+If this returns `503`, the app process is alive but not ready to serve traffic.
+
+## Route Matrix
+
+| Route | Auth | Notes |
+| --- | --- | --- |
+| `GET /health` | Public | Process liveness only |
+| `GET /ready` | Public | Includes database readiness |
+| `POST /api/auth/register` | Public | Creates a local account |
+| `POST /api/auth/login` | Public | Returns an access token for local auth |
+| `POST /api/auth/google` | Public | Returns an access token for Google auth |
+| `POST /api/auth/link/google` | Public | Requires valid local credentials plus a valid Google ID token |
+| `POST /api/auth/link/local` | Public | Requires a valid Google ID token |
+| `GET /api/users/me` | Bearer token | Current authenticated user |
+| `POST /api/tags` | Public | Tag creation is currently public |
+| `POST /api/presets` | Bearer token | Creates an owned preset |
+| `GET /api/presets` | Bearer token | Supports `?tag=<name>` |
+| `POST /api/presets/{id}/tags` | Bearer token | Attaches an existing tag to an existing preset |
+| `GET /api/presets/{id}` | Public | Preset detail is public |
+| `DELETE /api/presets/{id}` | Bearer token | Owner-only |
+| `GET /api/users/{id}/presets` | Bearer token | User-scoped preset list |
+
+## Common Success and Failure Signals
+
+### Authentication
+
+- `POST /api/auth/register`: `201` on success, `409` for duplicate or link-required cases
+- `POST /api/auth/login`: `200` on success, `401` for invalid credentials
+- `POST /api/auth/google`: `201` or `200` on success, `401` for invalid token, `409` for collision or link-required cases
+- `POST /api/auth/link/google`: `200` on success, `401` for invalid local credentials, `409` for account conflicts
+- `POST /api/auth/link/local`: `200` on success, `401` for invalid Google token, `409` for incompatible account state
+
+### Presets and Tags
+
+- `POST /api/tags`: `201` on success, `409` for duplicates
+- `POST /api/presets`: `201` on success, `401` without a valid bearer token
+- `GET /api/presets`: `200` on success, `401` without a valid bearer token
+- `POST /api/presets/{id}/tags`: `201` on success, `404` if the preset or tag is missing, `409` if the link already exists
+- `GET /api/presets/{id}`: `200` on success, `404` if missing
+- `DELETE /api/presets/{id}`: `204` on success, `403` for non-owner delete attempts, `404` if missing
 
 ## Database Operations
 
-### Where Schema Changes Live
+### Migrations
 
-Schema changes belong in:
+Flyway migrations live in:
 
 `src/main/resources/db/migration`
 
-### How Migrations Run
+Rules:
+- add new versioned SQL files
+- do not rewrite shared migrations
+- keep local schema changes migration-driven
 
-Flyway runs automatically during application startup.
+### Reset Local State
 
-### Migration Rules
-
-- add a new versioned file for every schema change
-- do not rewrite previously shared migrations
-- keep Hibernate schema mode at `validate`
-
-### Reset Local Database State
-
-If local schema state becomes inconsistent:
+If local database state is corrupted or out of sync:
 
 ```bash
 docker compose down -v
 docker compose up --build
 ```
 
-This removes the PostgreSQL volume and recreates the local database from scratch.
+This deletes the PostgreSQL volume and recreates the schema from migrations.
 
 ## Troubleshooting
 
-### The backend fails with a datasource validation or connection error
+### The backend fails on startup with datasource errors
 
 Check:
-
-- `SPRING_DATASOURCE_URL` is present
-- the URL starts with `jdbc:postgresql:`
-- username and password are present
-- the hostname matches the runtime mode you are using
-
-### The backend fails during Google auth configuration
-
-Check:
-
-- `MAGE_AUTH_GOOGLE_CLIENT_IDS` is present
-- the value contains the frontend Google OAuth client ID
-- multiple client IDs, if used, are comma-separated without extra quoting
-
-### PostgreSQL never becomes healthy in Docker Compose
-
-Check:
-
-- Docker is actually running
-- port `5432` is not already taken
-- the configured database username and password are valid in `.env`
-
-If needed, reset the volume:
-
-```bash
-docker compose down -v
-docker compose up --build
-```
+- `SPRING_DATASOURCE_URL`
+- `SPRING_DATASOURCE_USERNAME`
+- `SPRING_DATASOURCE_PASSWORD`
+- PostgreSQL container health
 
 ### `/ready` returns `503`
 
-Interpretation:
-
-- the backend process is up
-- either Spring is not yet accepting traffic or the database probe failed
-
 Check:
-
 - backend logs
-- PostgreSQL container health
-- datasource environment variables
+- PostgreSQL logs
+- datasource values in `.env`
 
-### `POST /api/auth/google` returns `401`
-
-Interpretation:
-
-- the Google ID token was invalid, expired, missing required claims, or the email was not verified
+### Google auth fails
 
 Check:
+- `MAGE_AUTH_GOOGLE_CLIENT_IDS` is set
+- the frontend sent a Google ID token, not an access token
+- the ID token was issued for one of the configured client IDs
 
-- the frontend sent an ID token, not an access token
-- the token was issued for a client ID listed in `MAGE_AUTH_GOOGLE_CLIENT_IDS`
-- the token has not expired
+### Tests fail before any assertions run
 
-### `POST /api/auth/google` returns `409`
+The usual cause is that Docker is unavailable, so Testcontainers cannot start PostgreSQL.
 
-Interpretation:
+### Ports are already in use
 
-- either a local-only account already owns that email and `/api/auth/link/google` must be used
-- or a different Google identity already owns that email in the backend
+The local stack expects:
+- `8080` for the backend
+- `5432` for PostgreSQL
 
-### `POST /api/auth/register` returns `409`
-
-Interpretation:
-
-- either local authentication is already configured for that email
-- or the email belongs to a Google-backed account and `/api/auth/link/local` must be used instead
-
-### `POST /api/auth/login` returns `401`
-
-Interpretation:
-
-- the supplied credentials did not match an account with local authentication
-
-### `POST /api/auth/link/google` returns `401`
-
-Interpretation:
-
-- the supplied local email/password pair did not pass the ownership check
-
-### `POST /api/auth/link/google` returns `409`
-
-Interpretation:
-
-- the Google token email does not match the local account email
-- or the Google identity is already linked to a different account
-
-### `POST /api/auth/link/local` returns `409`
-
-Interpretation:
-
-- the Google-backed account has not been provisioned yet through `POST /api/auth/google`
-- or the request conflicts with an incompatible existing account state
-
-### `GET /api/users/me` returns `401`
-
-Interpretation:
-
-- the request was missing a bearer token, the token was invalid, or the token points to a user record that no longer exists
-
-### `POST /api/tags` returns `409`
-
-Interpretation:
-
-- the supplied tag name already exists after normalization, so the backend rejects the duplicate tag creation request
-
-### `POST /api/presets` returns `401`
-
-Interpretation:
-
-- the request was missing a bearer token, the token was invalid, or the token points to a user record that no longer exists
-
-### `POST /api/presets/{id}/tags` returns `401`
-
-Interpretation:
-
-- the request was missing a bearer token, the token was invalid, or the token points to a user record that no longer exists
-
-### `GET /api/presets` returns `401`
-
-Interpretation:
-
-- the request was missing a bearer token, the token was invalid, or the token points to a user record that no longer exists
-
-### `DELETE /api/presets/{id}` returns `401`
-
-Interpretation:
-
-- the request was missing a bearer token, the token was invalid, or the token points to a user record that no longer exists
-
-### `GET /api/users/{id}/presets` returns `401`
-
-Interpretation:
-
-- the request was missing a bearer token, the token was invalid, or the token points to a user record that no longer exists
-
-### `GET /api/presets/{id}` returns `404`
-
-Interpretation:
-
-- no preset exists for that id, regardless of whether the caller is signed in
-
-### `DELETE /api/presets/{id}` returns `403`
-
-Interpretation:
-
-- the request was authenticated successfully, but the preset belongs to a different user
-
-### `DELETE /api/presets/{id}` returns `404`
-
-Interpretation:
-
-- the request was authenticated successfully, but no preset exists for that id
-
-### `POST /api/presets/{id}/tags` returns `404`
-
-Interpretation:
-
-- the request was authenticated successfully, but either the preset id or tag id did not match an existing record
-
-### `POST /api/presets/{id}/tags` returns `409`
-
-Interpretation:
-
-- the supplied tag is already attached to the preset, so the backend rejects the duplicate association request
-
-### Tests fail before running assertions
-
-Likely cause:
-
-- Docker is unavailable, so Testcontainers cannot start PostgreSQL
-
-### The database seems out of sync with migrations
-
-Check:
-
-- migration files are in the correct folder
-- filenames use Flyway naming conventions
-- local state was not carried forward from an old incompatible volume
-
-Resetting the local volume is usually the fastest way to recover.
-
-## Test Operations
-
-Run the full backend suite with:
-
-Windows PowerShell:
-
-```powershell
-.\mvnw.cmd test
-```
-
-macOS/Linux:
-
-```bash
-./mvnw test
-```
-
-
+Stop the conflicting process or adjust the local port mapping.


### PR DESCRIPTION
## Summary

This PR rewrites the backend README and core docs so the repository reads like a maintained service repo instead of a set of long internal notes.

## What Changed

- rewrote the root `README.md` to cover:
  - project overview
  - stack
  - getting started
  - configuration
  - current API surface
  - repository layout
  - docs links
  - current backend scope
- added `docs/README.md` as a docs index and recommended reading order
- rewrote:
  - `docs/getting-started.md`
  - `docs/architecture.md`
  - `docs/engineering-standards.md`
  - `docs/operations.md`
- updated `CONTRIBUTING.md` so the contribution workflow matches the new docs set
- reduced repeated endpoint and setup prose across documents and gave each doc a clearer purpose

## Notes

- this is a docs-only PR
- `docs/docker-compose-install` and `docs/tag-filter-testing` were intentionally left unchanged

## Why

The previous backend docs had useful information, but too much of it was repeated across multiple files. This PR makes the repo easier to use by tightening the documentation around:

- local setup and environment expectations
- current backend architecture and request flow
- operational checks and troubleshooting
- engineering and review standards
- contribution workflow

## Testing

- not run, docs-only change
