### PR TITLE
Prepare backend for same-origin deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,12 +2,12 @@ FROM eclipse-temurin:21-jdk AS build
 WORKDIR /app
 
 COPY . .
-RUN ./mvnw clean package -DskipTests
+RUN chmod +x mvnw && ./mvnw clean package -DskipTests
 
 FROM eclipse-temurin:21-jre
 WORKDIR /app
 
-COPY --from=build /app/target/mage-backend-0.0.1-SNAPSHOT.jar app.jar
+COPY --from=build /app/target/*.jar app.jar
 
 EXPOSE 8080
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/README.md
+++ b/README.md
@@ -85,6 +85,17 @@ Other useful defaults in `.env.example`:
 - `POSTGRES_USER`
 - `POSTGRES_PASSWORD`
 
+## Deployment Strategy
+
+The supported production path is same-origin deployment behind a reverse proxy:
+
+- the frontend is served from the public app origin
+- `/api/*` is routed to this backend service
+- browser auth requests stay on the same HTTPS origin as the frontend
+- CORS is not part of the supported deployment path
+
+See [docs/deployment.md](docs/deployment.md) for the expected reverse-proxy contract and the required backend environment variables.
+
 ## Current API Surface
 
 | Route | Auth | Purpose |
@@ -135,6 +146,7 @@ mage-backend/
 
 - [docs/README.md](docs/README.md): documentation index and reading order
 - [docs/getting-started.md](docs/getting-started.md): local setup, configuration, tests, and first verification steps
+- [docs/deployment.md](docs/deployment.md): same-origin production deployment contract and reverse-proxy expectations
 - [docs/architecture.md](docs/architecture.md): package layout, request flow, auth model, and persistence model
 - [docs/operations.md](docs/operations.md): runbook, health checks, auth matrix, and troubleshooting
 - [docs/engineering-standards.md](docs/engineering-standards.md): coding, API, testing, and review expectations

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,13 +6,15 @@ Use these docs as the source of truth for working in `mage-backend`.
 
 1. [../README.md](../README.md)
 2. [getting-started.md](getting-started.md)
-3. [architecture.md](architecture.md)
-4. [engineering-standards.md](engineering-standards.md)
-5. [operations.md](operations.md)
+3. [deployment.md](deployment.md)
+4. [architecture.md](architecture.md)
+5. [engineering-standards.md](engineering-standards.md)
+6. [operations.md](operations.md)
 
 ## Guides
 
 - [getting-started.md](getting-started.md): local setup, environment variables, tests, and first verification steps
+- [deployment.md](deployment.md): same-origin production deployment contract, backend env vars, and reverse-proxy expectations
 - [architecture.md](architecture.md): package layout, request flow, auth model, and persistence model
 - [engineering-standards.md](engineering-standards.md): coding, API, persistence, testing, and review expectations
 - [operations.md](operations.md): runbook, route auth matrix, migrations, and troubleshooting

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,63 @@
+# Backend Deployment
+
+This backend is intended to be deployed behind a same-origin reverse proxy.
+
+## Supported Production Contract
+
+The public deployment model is:
+
+- the frontend is served from the public app origin
+- `/api/*` is routed to the backend service
+- browser auth traffic stays on the same HTTPS origin
+- CORS is not required for the supported path
+
+Example:
+
+```text
+https://mage.example.com/        -> frontend
+https://mage.example.com/api/*   -> backend
+```
+
+## Required Environment Variables
+
+The backend must receive:
+
+| Variable | Purpose |
+| --- | --- |
+| `SERVER_PORT` | Application port. Defaults to `8080`. |
+| `SPRING_DATASOURCE_URL` | PostgreSQL JDBC URL. |
+| `SPRING_DATASOURCE_USERNAME` | Database username. |
+| `SPRING_DATASOURCE_PASSWORD` | Database password. |
+| `MAGE_AUTH_GOOGLE_CLIENT_IDS` | Allowed Google OAuth client IDs for Google sign-in validation. |
+
+The backend will fail fast if required datasource values or `MAGE_AUTH_GOOGLE_CLIENT_IDS` are missing.
+
+## Reverse Proxy Expectations
+
+The reverse proxy should:
+
+- route `/api/*` to the backend service
+- keep the frontend on the public app origin for all non-API browser routes
+- terminate HTTPS for browser-facing traffic
+
+This repository does not currently treat split-origin frontend/backend deployment as the primary path.
+
+## Container Notes
+
+The backend repo includes a production `Dockerfile`.
+
+It:
+- builds the app with the Maven wrapper
+- packages the Spring Boot jar
+- runs the jar on a JRE image
+
+For Linux-based builders such as Coolify, the Dockerfile explicitly sets execute permission on `mvnw` during the build so it works reliably even when the repo was created on Windows.
+
+## Local Development
+
+None of this replaces the local Docker Compose workflow in this repo.
+
+For local development:
+- keep using `.env`
+- keep using `docker compose up --build`
+- keep using the frontend Vite proxy or local same-origin-equivalent paths during development

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -2,6 +2,15 @@
 
 This document is the practical runbook for starting, checking, and troubleshooting the backend.
 
+## Supported Production Model
+
+The supported deployment path is same-origin:
+- the frontend is served from the public app origin
+- `/api/*` is routed to the backend by the reverse proxy
+- the backend is not expected to serve browser traffic from a second public origin
+
+This keeps the current bearer-token auth flow working without introducing CORS requirements into the supported deployment path.
+
 ## Local Runtime Model
 
 The standard local stack has two services:
@@ -29,6 +38,8 @@ docker compose logs -f backend
 docker compose logs -f postgres
 ```
 
+For production deployment notes, use [deployment.md](deployment.md).
+
 ## Health Checks
 
 ### `GET /health`
@@ -52,6 +63,8 @@ Healthy response:
 ```
 
 If this returns `503`, the app process is alive but not ready to serve traffic.
+
+In the supported same-origin deployment model, these health endpoints are typically checked on the backend service itself or through platform health checks, not through the public frontend domain.
 
 ## Route Matrix
 


### PR DESCRIPTION
## Summary

This PR prepares `mage-backend` for the supported production deployment path: a same-origin reverse-proxy setup where the frontend serves the public app origin and `/api/*` is routed to the backend service.

## What Changed

- updated the backend `Dockerfile` so the Maven wrapper works reliably in Linux-based builders by setting execute permission during image build
- added backend deployment documentation for the same-origin production contract
- updated the backend README and docs index to include deployment guidance
- updated operations documentation to describe the supported production model and clarify how backend health checks fit into that setup

## Why

The backend already ran locally, but the repo did not clearly document the intended production routing model and the Docker build was brittle on Linux hosts if `mvnw` did not retain execute permission from the local filesystem.

This PR makes the backend deployment path clearer and more reliable for environments like Coolify without changing the local Docker Compose workflow.

## Verification

- `.\mvnw.cmd test`
- `docker build -t mage-backend-deploy-test .`

## Notes

- local Docker Compose development is unchanged
- this PR documents and supports the same-origin deployment strategy
