### PR TITLE
Split local and deployment compose ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,20 @@ Windows PowerShell:
 
 ```powershell
 Copy-Item .env.example .env
-docker compose up --build
+docker compose -f docker-compose.yml -f docker-compose.local.yml up --build
 ```
 
 macOS/Linux:
 
 ```bash
 cp .env.example .env
-docker compose up --build
+docker compose -f docker-compose.yml -f docker-compose.local.yml up --build
 ```
+
+`docker-compose.yml` stays deployment-friendly and does not publish host ports.
+`docker-compose.local.yml` adds the local host bindings for:
+- backend: `http://localhost:8080`
+- postgres: `localhost:5432`
 
 Once the stack is up:
 - app: `http://localhost:8080`
@@ -125,6 +130,7 @@ mage-backend/
 |  |     `- db/migration/
 |  `- test/
 |- CONTRIBUTING.md
+|- docker-compose.local.yml
 |- docker-compose.yml
 |- Dockerfile
 |- pom.xml

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,8 @@
+services:
+  postgres:
+    ports:
+      - "5432:5432"
+
+  backend:
+    ports:
+      - "8080:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,6 @@ services:
       POSTGRES_DB: ${POSTGRES_DB}
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-    ports:
-      - "5432:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,3 +16,5 @@ Use these docs as the source of truth for working in `mage-backend`.
 - [architecture.md](architecture.md): package layout, request flow, auth model, and persistence model
 - [engineering-standards.md](engineering-standards.md): coding, API, persistence, testing, and review expectations
 - [operations.md](operations.md): runbook, route auth matrix, migrations, and troubleshooting
+- [docker-compose-install/README.md](docker-compose-install/README.md): Docker Desktop / Compose installation notes for local backend work
+- [tag-filter-testing/README.md](tag-filter-testing/README.md): manual backend verification flow for tag-filter behavior

--- a/docs/docker-compose-install/README.md
+++ b/docs/docker-compose-install/README.md
@@ -82,8 +82,12 @@ If Docker Desktop is installed, start it before running backend commands.
 You should then be able to run:
 
 ```bash
-docker compose up --build
+docker compose -f docker-compose.yml -f docker-compose.local.yml up --build
 ```
+
+For this repository:
+- `docker-compose.yml` is the deployment-friendly base file
+- `docker-compose.local.yml` adds the local host ports needed for `localhost:8080` and `localhost:5432`
 
 ## Next Step
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,19 +21,23 @@ Windows PowerShell:
 
 ```powershell
 Copy-Item .env.example .env
-docker compose up --build
+docker compose -f docker-compose.yml -f docker-compose.local.yml up --build
 ```
 
 macOS/Linux:
 
 ```bash
 cp .env.example .env
-docker compose up --build
+docker compose -f docker-compose.yml -f docker-compose.local.yml up --build
 ```
 
 This starts:
 - `postgres`: PostgreSQL 16
 - `backend`: the Spring Boot service from this repo
+
+The split is intentional:
+- `docker-compose.yml`: base services for deployment-friendly container networking
+- `docker-compose.local.yml`: local-only host port bindings for `8080` and `5432`
 
 ## Environment Variables
 
@@ -105,7 +109,7 @@ If local schema state gets messy, the quickest reset is:
 
 ```bash
 docker compose down -v
-docker compose up --build
+docker compose -f docker-compose.yml -f docker-compose.local.yml up --build
 ```
 
 ## Common Local Issues

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -108,7 +108,7 @@ Migration rules:
 If local schema state gets messy, the quickest reset is:
 
 ```bash
-docker compose down -v
+docker compose -f docker-compose.yml -f docker-compose.local.yml down -v
 docker compose -f docker-compose.yml -f docker-compose.local.yml up --build
 ```
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -114,7 +114,7 @@ Rules:
 If local database state is corrupted or out of sync:
 
 ```bash
-docker compose down -v
+docker compose -f docker-compose.yml -f docker-compose.local.yml down -v
 docker compose -f docker-compose.yml -f docker-compose.local.yml up --build
 ```
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -18,8 +18,12 @@ Operationally important behavior:
 ## Start the Stack
 
 ```bash
-docker compose up --build
+docker compose -f docker-compose.yml -f docker-compose.local.yml up --build
 ```
+
+Use the base file plus the local file for host access:
+- `docker-compose.yml`: deployment-friendly base definition
+- `docker-compose.local.yml`: local-only port publishing
 
 Useful log commands:
 
@@ -111,7 +115,7 @@ If local database state is corrupted or out of sync:
 
 ```bash
 docker compose down -v
-docker compose up --build
+docker compose -f docker-compose.yml -f docker-compose.local.yml up --build
 ```
 
 This deletes the PostgreSQL volume and recreates the schema from migrations.
@@ -146,8 +150,8 @@ The usual cause is that Docker is unavailable, so Testcontainers cannot start Po
 
 ### Ports are already in use
 
-The local stack expects:
+The local override publishes:
 - `8080` for the backend
 - `5432` for PostgreSQL
 
-Stop the conflicting process or adjust the local port mapping.
+If either port is busy, either stop the conflicting process or edit `docker-compose.local.yml`.

--- a/docs/tag-filter-testing/README.md
+++ b/docs/tag-filter-testing/README.md
@@ -38,7 +38,7 @@ Copy-Item .env.example .env
 ## 4. Start the Backend and Database
 
 ```powershell
-docker compose up --build
+docker compose -f docker-compose.yml -f docker-compose.local.yml up --build
 ```
 
 Wait until the backend is healthy and listening on `http://localhost:8080`.
@@ -172,7 +172,6 @@ Ctrl+C
 To remove containers afterward:
 
 ```powershell
-docker compose down
+docker compose -f docker-compose.yml -f docker-compose.local.yml down
 ```
-
 


### PR DESCRIPTION
## What Changed

- split local host port publishing out of the base backend compose file
- kept `docker-compose.yml` deployment-friendly with no host port bindings
- added `docker-compose.local.yml` for local-only host access:
  - backend `8080:8080`
  - postgres `5432:5432`
- updated backend docs to use the local compose pair for local development:
  - `README.md`
  - `docs/getting-started.md`
  - `docs/operations.md`

## Why It Changed

Removing backend host port publishing fixed deployment conflicts, but it also broke local frontend preview and direct local API testing because nothing on the host was listening on `localhost:8080`.

This change keeps deployment clean while restoring the expected local development workflow.

## How It Was Tested

- validated merged compose output with:
  - `docker compose -f docker-compose.yml -f docker-compose.local.yml config`

## Configuration / API / Schema Impact

- adds a new local-only compose file:
  - `docker-compose.local.yml`
- changes the documented local startup command to:
  - `docker compose -f docker-compose.yml -f docker-compose.local.yml up --build`
- no public API changes
- no database/schema changes
