### PR TITLE
82 add tag creation flow to preset editor

### DIFF
--- a/src/main/java/com/bdmage/mage_backend/controller/PresetController.java
+++ b/src/main/java/com/bdmage/mage_backend/controller/PresetController.java
@@ -87,8 +87,9 @@ public class PresetController {
 	@GetMapping("/{id}")
 	ResponseEntity<PresetResponse> getPreset(@PathVariable Long id) {
 		Preset preset = this.presetService.getPreset(id);
+		List<String> tagNames = this.presetService.getTagNamesForPreset(id);
 
-		return ResponseEntity.ok(this.presetResponseFactory.from(preset));
+		return ResponseEntity.ok(this.presetResponseFactory.from(preset, tagNames));
 	}
 
 	@PostMapping("/{id}/thumbnail/presign")

--- a/src/main/java/com/bdmage/mage_backend/controller/TagController.java
+++ b/src/main/java/com/bdmage/mage_backend/controller/TagController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -26,8 +27,11 @@ public class TagController {
 	}
 
 	@GetMapping
-	ResponseEntity<List<TagResponse>> getAllTags() {
-		List<Tag> tags = this.tagService.getAllTags();
+	ResponseEntity<List<TagResponse>> getAllTags(
+			@RequestParam(name = "attachedOnly", defaultValue = "false") boolean attachedOnly) {
+		List<Tag> tags = attachedOnly
+				? this.tagService.getAllTagsAttachedToPresets()
+				: this.tagService.getAllTags();
 
 		return ResponseEntity.ok(tags.stream()
 				.map(TagResponse::from)

--- a/src/main/java/com/bdmage/mage_backend/dto/PresetResponse.java
+++ b/src/main/java/com/bdmage/mage_backend/dto/PresetResponse.java
@@ -1,6 +1,7 @@
 package com.bdmage.mage_backend.dto;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
 
 import com.bdmage.mage_backend.model.Preset;
@@ -14,13 +15,18 @@ public record PresetResponse(
 		String name,
 		Map<String, Object> sceneData,
 		String thumbnailRef,
-		Instant createdAt) {
+		Instant createdAt,
+		List<String> tags) {
 
 	private static final ObjectMapper JSON_OBJECT_MAPPER = new ObjectMapper();
 	private static final TypeReference<Map<String, Object>> SCENE_DATA_TYPE = new TypeReference<>() {
 	};
 
 	public static PresetResponse from(Preset preset, String creatorDisplayName) {
+		return from(preset, creatorDisplayName, List.of());
+	}
+
+	public static PresetResponse from(Preset preset, String creatorDisplayName, List<String> tags) {
 		return new PresetResponse(
 				preset.getId(),
 				preset.getOwnerUserId(),
@@ -28,6 +34,7 @@ public record PresetResponse(
 				preset.getName(),
 				JSON_OBJECT_MAPPER.convertValue(preset.getSceneData(), SCENE_DATA_TYPE),
 				preset.getThumbnailRef(),
-				preset.getCreatedAt());
+				preset.getCreatedAt(),
+				List.copyOf(tags));
 	}
 }

--- a/src/main/java/com/bdmage/mage_backend/repository/TagRepository.java
+++ b/src/main/java/com/bdmage/mage_backend/repository/TagRepository.java
@@ -4,8 +4,21 @@ import java.util.Optional;
 
 import com.bdmage.mage_backend.model.Tag;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
 
     Optional<Tag> findByName(String name);
+
+    @Query("""
+            SELECT tag
+            FROM Tag tag
+            WHERE EXISTS (
+                SELECT 1
+                FROM PresetTag presetTag
+                WHERE presetTag.tagId = tag.id
+            )
+            ORDER BY tag.name ASC
+            """)
+    java.util.List<Tag> findAllAttachedToPresets();
 }

--- a/src/main/java/com/bdmage/mage_backend/service/PresetResponseFactory.java
+++ b/src/main/java/com/bdmage/mage_backend/service/PresetResponseFactory.java
@@ -22,11 +22,11 @@ public class PresetResponseFactory {
 	}
 
 	public PresetResponse from(Preset preset) {
-		return PresetResponse.from(
-				preset,
-				this.userRepository.findById(preset.getOwnerUserId())
-						.map(User::getDisplayName)
-						.orElse(UNKNOWN_CREATOR_DISPLAY_NAME));
+		return PresetResponse.from(preset, resolveCreatorDisplayName(preset));
+	}
+
+	public PresetResponse from(Preset preset, List<String> tags) {
+		return PresetResponse.from(preset, resolveCreatorDisplayName(preset), tags);
 	}
 
 	public List<PresetResponse> from(List<Preset> presets) {
@@ -46,6 +46,12 @@ public class PresetResponseFactory {
 
 		return this.userRepository.findAllById(ownerUserIds).stream()
 				.collect(java.util.stream.Collectors.toMap(User::getId, User::getDisplayName));
+	}
+
+	private String resolveCreatorDisplayName(Preset preset) {
+		return this.userRepository.findById(preset.getOwnerUserId())
+				.map(User::getDisplayName)
+				.orElse(UNKNOWN_CREATOR_DISPLAY_NAME);
 	}
 
 }

--- a/src/main/java/com/bdmage/mage_backend/service/PresetService.java
+++ b/src/main/java/com/bdmage/mage_backend/service/PresetService.java
@@ -14,6 +14,7 @@ import com.bdmage.mage_backend.exception.PresetTagAlreadyExistsException;
 import com.bdmage.mage_backend.exception.TagNotFoundException;
 import com.bdmage.mage_backend.model.Preset;
 import com.bdmage.mage_backend.model.PresetTag;
+import com.bdmage.mage_backend.model.Tag;
 import com.bdmage.mage_backend.repository.PresetRepository;
 import com.bdmage.mage_backend.repository.PresetTagRepository;
 import com.bdmage.mage_backend.repository.TagRepository;
@@ -142,6 +143,23 @@ public class PresetService {
 	@Transactional(readOnly = true)
 	public List<Preset> getPresetsByTag(String tag) {
 		return this.presetRepository.findAllByTagName(normalizeTagName(tag));
+	}
+
+	@Transactional(readOnly = true)
+	public List<String> getTagNamesForPreset(Long presetId) {
+		List<Long> tagIds = this.presetTagRepository.findAllByPresetId(presetId).stream()
+				.map(PresetTag::getTagId)
+				.distinct()
+				.toList();
+
+		if (tagIds.isEmpty()) {
+			return List.of();
+		}
+
+		return this.tagRepository.findAllById(tagIds).stream()
+				.map(Tag::getName)
+				.sorted()
+				.toList();
 	}
 
 	@Transactional

--- a/src/main/java/com/bdmage/mage_backend/service/TagService.java
+++ b/src/main/java/com/bdmage/mage_backend/service/TagService.java
@@ -42,6 +42,11 @@ public class TagService {
 		return this.tagRepository.findAll(Sort.by(Sort.Direction.ASC, "name"));
 	}
 
+	@Transactional(readOnly = true)
+	public List<Tag> getAllTagsAttachedToPresets() {
+		return this.tagRepository.findAllAttachedToPresets();
+	}
+
 	private static String normalizeName(String name) {
 		return name.trim().toLowerCase(Locale.ROOT);
 	}

--- a/src/test/java/com/bdmage/mage_backend/controller/PresetControllerIntegrationTests.java
+++ b/src/test/java/com/bdmage/mage_backend/controller/PresetControllerIntegrationTests.java
@@ -377,6 +377,8 @@ class PresetControllerIntegrationTests extends PostgresIntegrationTestSupport {
 	void getPresetReturnsPresetWithAllFieldsForPublicRequest() throws Exception {
 		String uniqueSuffix = String.valueOf(System.nanoTime());
 		String email = "public-get-preset-user-" + uniqueSuffix + "@example.com";
+		String showcaseTagName = "showcase-" + uniqueSuffix;
+		String ambientTagName = "ambient-" + uniqueSuffix;
 
 		User savedUser = this.userRepository.saveAndFlush(new User(
 				email,
@@ -390,6 +392,10 @@ class PresetControllerIntegrationTests extends PostgresIntegrationTestSupport {
 						{"visualizer":{"shader":"nebula"},"state":{"energy":0.92}}
 						"""),
 				"thumbnails/preset-1.png"));
+		Tag showcaseTag = this.tagRepository.saveAndFlush(new Tag(showcaseTagName));
+		Tag ambientTag = this.tagRepository.saveAndFlush(new Tag(ambientTagName));
+		this.presetTagRepository.saveAndFlush(new PresetTag(savedPreset.getId(), showcaseTag.getId()));
+		this.presetTagRepository.saveAndFlush(new PresetTag(savedPreset.getId(), ambientTag.getId()));
 
 		this.mockMvc.perform(get("/api/presets/" + savedPreset.getId())
 				.contentType(MediaType.APPLICATION_JSON))
@@ -401,7 +407,9 @@ class PresetControllerIntegrationTests extends PostgresIntegrationTestSupport {
 				.andExpect(jsonPath("$.sceneData.visualizer.shader").value("nebula"))
 				.andExpect(jsonPath("$.sceneData.state.energy").value(0.92))
 				.andExpect(jsonPath("$.thumbnailRef").value("thumbnails/preset-1.png"))
-				.andExpect(jsonPath("$.createdAt").isNotEmpty());
+				.andExpect(jsonPath("$.createdAt").isNotEmpty())
+				.andExpect(jsonPath("$.tags[0]").value(ambientTagName))
+				.andExpect(jsonPath("$.tags[1]").value(showcaseTagName));
 	}
 
 	@Test
@@ -409,6 +417,8 @@ class PresetControllerIntegrationTests extends PostgresIntegrationTestSupport {
 		String uniqueSuffix = String.valueOf(System.nanoTime());
 		String email = "get-preset-user-" + uniqueSuffix + "@example.com";
 		String password = "password-" + uniqueSuffix;
+		String showcaseTagName = "showcase-auth-" + uniqueSuffix;
+		String ambientTagName = "ambient-auth-" + uniqueSuffix;
 
 		User savedUser = this.userRepository.saveAndFlush(new User(
 				email,
@@ -429,6 +439,10 @@ class PresetControllerIntegrationTests extends PostgresIntegrationTestSupport {
 						{"visualizer":{"shader":"nebula"},"state":{"energy":0.92}}
 						"""),
 				"thumbnails/preset-1.png"));
+		Tag showcaseTag = this.tagRepository.saveAndFlush(new Tag(showcaseTagName));
+		Tag ambientTag = this.tagRepository.saveAndFlush(new Tag(ambientTagName));
+		this.presetTagRepository.saveAndFlush(new PresetTag(savedPreset.getId(), showcaseTag.getId()));
+		this.presetTagRepository.saveAndFlush(new PresetTag(savedPreset.getId(), ambientTag.getId()));
 
 		this.mockMvc.perform(get("/api/presets/" + savedPreset.getId())
 				.header("Authorization", "Bearer " + accessToken)
@@ -441,7 +455,9 @@ class PresetControllerIntegrationTests extends PostgresIntegrationTestSupport {
 				.andExpect(jsonPath("$.sceneData.visualizer.shader").value("nebula"))
 				.andExpect(jsonPath("$.sceneData.state.energy").value(0.92))
 				.andExpect(jsonPath("$.thumbnailRef").value("thumbnails/preset-1.png"))
-				.andExpect(jsonPath("$.createdAt").isNotEmpty());
+				.andExpect(jsonPath("$.createdAt").isNotEmpty())
+				.andExpect(jsonPath("$.tags[0]").value(ambientTagName))
+				.andExpect(jsonPath("$.tags[1]").value(showcaseTagName));
 	}
 
 	@Test

--- a/src/test/java/com/bdmage/mage_backend/controller/PresetControllerTests.java
+++ b/src/test/java/com/bdmage/mage_backend/controller/PresetControllerTests.java
@@ -324,6 +324,7 @@ class PresetControllerTests {
 		ReflectionTestUtils.setField(preset, "createdAt", Instant.parse("2026-03-26T15:30:00Z"));
 
 		when(this.presetService.getPreset(15L)).thenReturn(preset);
+		when(this.presetService.getTagNamesForPreset(15L)).thenReturn(List.of("ambient", "showcase"));
 		when(this.userRepository.findById(77L)).thenReturn(Optional.of(user(77L, "Preset Creator")));
 
 		this.mockMvc.perform(get("/api/presets/15"))
@@ -336,7 +337,9 @@ class PresetControllerTests {
 				.andExpect(jsonPath("$.sceneData.visualizer.shader").value("nebula"))
 				.andExpect(jsonPath("$.sceneData.state.energy").value(0.92))
 				.andExpect(jsonPath("$.thumbnailRef").value("https://cdn.example.com/presets/15/thumbnails/thumb.png"))
-				.andExpect(jsonPath("$.createdAt").value("2026-03-26T15:30:00Z"));
+				.andExpect(jsonPath("$.createdAt").value("2026-03-26T15:30:00Z"))
+				.andExpect(jsonPath("$.tags[0]").value("ambient"))
+				.andExpect(jsonPath("$.tags[1]").value("showcase"));
 	}
 
 	@Test

--- a/src/test/java/com/bdmage/mage_backend/controller/TagControllerIntegrationTests.java
+++ b/src/test/java/com/bdmage/mage_backend/controller/TagControllerIntegrationTests.java
@@ -1,8 +1,15 @@
 package com.bdmage.mage_backend.controller;
 
+import com.bdmage.mage_backend.model.Preset;
+import com.bdmage.mage_backend.model.PresetTag;
 import com.bdmage.mage_backend.model.Tag;
+import com.bdmage.mage_backend.model.User;
+import com.bdmage.mage_backend.repository.PresetRepository;
+import com.bdmage.mage_backend.repository.PresetTagRepository;
 import com.bdmage.mage_backend.repository.TagRepository;
+import com.bdmage.mage_backend.repository.UserRepository;
 import com.bdmage.mage_backend.support.PostgresIntegrationTestSupport;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,15 +35,29 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @Testcontainers
 class TagControllerIntegrationTests extends PostgresIntegrationTestSupport {
 
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
 	@Autowired
 	private MockMvc mockMvc;
 
 	@Autowired
 	private TagRepository tagRepository;
 
+	@Autowired
+	private PresetRepository presetRepository;
+
+	@Autowired
+	private PresetTagRepository presetTagRepository;
+
+	@Autowired
+	private UserRepository userRepository;
+
 	@BeforeEach
 	void clearTags() {
+		this.presetTagRepository.deleteAll();
+		this.presetRepository.deleteAll();
 		this.tagRepository.deleteAll();
+		this.userRepository.deleteAll();
 	}
 
 	@Test
@@ -91,5 +112,28 @@ class TagControllerIntegrationTests extends PostgresIntegrationTestSupport {
 				.andExpect(status().isBadRequest())
 				.andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
 				.andExpect(jsonPath("$.details.name").value("name must not be blank"));
+	}
+
+	@Test
+	void getAllTagsWithAttachedOnlyReturnsOnlyTagsAttachedToPresets() throws Exception {
+		User owner = this.userRepository.saveAndFlush(
+				new User("tag-controller-attached-owner-" + System.nanoTime() + "@example.com", "hashed-password-value",
+						"Tag Controller Owner"));
+		Preset preset = this.presetRepository.saveAndFlush(new Preset(
+				owner.getId(),
+				"Aurora Drift",
+				this.objectMapper.readTree("""
+						{"visualizer":{"shader":"nebula"}}
+						""")));
+		Tag ambient = this.tagRepository.saveAndFlush(new Tag("ambient"));
+		this.tagRepository.saveAndFlush(new Tag("unused"));
+		Tag showcase = this.tagRepository.saveAndFlush(new Tag("showcase"));
+
+		this.presetTagRepository.saveAndFlush(new PresetTag(preset.getId(), showcase.getId()));
+		this.presetTagRepository.saveAndFlush(new PresetTag(preset.getId(), ambient.getId()));
+
+		this.mockMvc.perform(get("/api/tags?attachedOnly=true"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$[*].name", contains("ambient", "showcase")));
 	}
 }

--- a/src/test/java/com/bdmage/mage_backend/controller/TagControllerTests.java
+++ b/src/test/java/com/bdmage/mage_backend/controller/TagControllerTests.java
@@ -83,6 +83,20 @@ class TagControllerTests {
 	}
 
 	@Test
+	void getAllTagsWithAttachedOnlyReturnsAttachedTagResponses() throws Exception {
+		Tag ambient = new Tag("ambient");
+		ReflectionTestUtils.setField(ambient, "id", 15L);
+
+		when(this.tagService.getAllTagsAttachedToPresets()).thenReturn(List.of(ambient));
+
+		this.mockMvc.perform(get("/api/tags?attachedOnly=true"))
+				.andExpect(status().isOk())
+				.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+				.andExpect(jsonPath("$[0].tagId").value(15L))
+				.andExpect(jsonPath("$[0].name").value("ambient"));
+	}
+
+	@Test
 	void createTagRejectsInvalidRequestBody() throws Exception {
 		this.mockMvc.perform(post("/api/tags")
 				.contentType(MediaType.APPLICATION_JSON)

--- a/src/test/java/com/bdmage/mage_backend/repository/TagRepositoryIntegrationTest.java
+++ b/src/test/java/com/bdmage/mage_backend/repository/TagRepositoryIntegrationTest.java
@@ -1,9 +1,14 @@
 package com.bdmage.mage_backend.repository;
 
+import com.bdmage.mage_backend.model.Preset;
+import com.bdmage.mage_backend.model.PresetTag;
 import com.bdmage.mage_backend.model.Tag;
+import com.bdmage.mage_backend.model.User;
 import com.bdmage.mage_backend.support.PostgresIntegrationTestSupport;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -21,11 +26,30 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @Testcontainers
 class TagRepositoryIntegrationTest extends PostgresIntegrationTestSupport {
 
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
     @Autowired
     private TagRepository tagRepository;
 
+    @Autowired
+    private PresetRepository presetRepository;
+
+    @Autowired
+    private PresetTagRepository presetTagRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
     @PersistenceContext
     private EntityManager entityManager;
+
+    @BeforeEach
+    void clearData() {
+        this.presetTagRepository.deleteAll();
+        this.presetRepository.deleteAll();
+        this.tagRepository.deleteAll();
+        this.userRepository.deleteAll();
+    }
 
     @Test
     void savesTagAndNormalizesName() {
@@ -46,5 +70,32 @@ class TagRepositoryIntegrationTest extends PostgresIntegrationTestSupport {
 
         assertThatThrownBy(() -> tagRepository.saveAndFlush(new Tag("EDM")))
                 .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void findAllAttachedToPresetsReturnsOnlyTagsWithPresetLinksSortedByName() throws Exception {
+        User owner = this.userRepository.saveAndFlush(
+                new User("attached-tags-owner-" + System.nanoTime() + "@example.com", "hashed-password-value", "Attached Tags Owner"));
+        Preset preset = this.presetRepository.saveAndFlush(new Preset(
+                owner.getId(),
+                "Aurora Drift",
+                this.objectMapper.readTree("""
+                        {"visualizer":{"shader":"nebula"}}
+                        """)));
+        Tag unusedTag = this.tagRepository.saveAndFlush(new Tag("unused"));
+        Tag showcaseTag = this.tagRepository.saveAndFlush(new Tag("showcase"));
+        Tag ambientTag = this.tagRepository.saveAndFlush(new Tag("ambient"));
+
+        this.presetTagRepository.saveAndFlush(new PresetTag(preset.getId(), showcaseTag.getId()));
+        this.presetTagRepository.saveAndFlush(new PresetTag(preset.getId(), ambientTag.getId()));
+
+        this.entityManager.clear();
+
+        assertThat(this.tagRepository.findAllAttachedToPresets())
+                .extracting(Tag::getName)
+                .containsExactly("ambient", "showcase");
+        assertThat(this.tagRepository.findAllAttachedToPresets())
+                .extracting(Tag::getId)
+                .doesNotContain(unusedTag.getId());
     }
 }

--- a/src/test/java/com/bdmage/mage_backend/service/PresetServiceTests.java
+++ b/src/test/java/com/bdmage/mage_backend/service/PresetServiceTests.java
@@ -299,6 +299,23 @@ class PresetServiceTests {
 	}
 
 	@Test
+	void getTagNamesForPresetReturnsSortedAttachedTagNames() {
+		PresetRepository presetRepository = mock(PresetRepository.class);
+		TagRepository tagRepository = mock(TagRepository.class);
+		PresetTagRepository presetTagRepository = mock(PresetTagRepository.class);
+		UserRepository userRepository = mock(UserRepository.class);
+		PresetService presetService = presetService(presetRepository, tagRepository, presetTagRepository, userRepository);
+
+		when(presetTagRepository.findAllByPresetId(15L))
+				.thenReturn(List.of(new PresetTag(15L, 7L), new PresetTag(15L, 6L)));
+		when(tagRepository.findAllById(List.of(7L, 6L)))
+				.thenReturn(List.of(new com.bdmage.mage_backend.model.Tag("showcase"), new com.bdmage.mage_backend.model.Tag("ambient")));
+
+		assertThat(presetService.getTagNamesForPreset(15L)).containsExactly("ambient", "showcase");
+		verifyNoInteractions(userRepository);
+	}
+
+	@Test
 	void attachTagToPresetSavesAssociationForAuthenticatedUser() {
 		PresetRepository presetRepository = mock(PresetRepository.class);
 		TagRepository tagRepository = mock(TagRepository.class);

--- a/src/test/java/com/bdmage/mage_backend/service/TagServiceTests.java
+++ b/src/test/java/com/bdmage/mage_backend/service/TagServiceTests.java
@@ -13,8 +13,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
 
 class TagServiceTests {
@@ -63,5 +63,17 @@ class TagServiceTests {
 		assertThatThrownBy(() -> tagService.createTag("Ambient"))
 				.isInstanceOf(TagAlreadyExistsException.class)
 				.hasMessage("A tag with this name already exists.");
+	}
+
+	@Test
+	void getAllTagsAttachedToPresetsDelegatesToRepositoryQuery() {
+		TagRepository tagRepository = mock(TagRepository.class);
+		TagService tagService = new TagService(tagRepository);
+		Tag ambient = new Tag("ambient");
+
+		when(tagRepository.findAllAttachedToPresets()).thenReturn(java.util.List.of(ambient));
+
+		assertThat(tagService.getAllTagsAttachedToPresets()).containsExactly(ambient);
+		verify(tagRepository).findAllAttachedToPresets();
 	}
 }


### PR DESCRIPTION
## Summary

Adds the backend tag discovery support needed by the preset editor and preset detail page.

## What changed

- include attached tags in preset detail responses
- add `attachedOnly=true` support to `GET /api/tags`
- return only tags that are actually attached to presets when `attachedOnly=true`
- keep existing tag create and preset-tag attach endpoints unchanged
- add controller, service, repository, and integration test coverage for the new behavior

## API changes

### `GET /api/presets/{id}`
Preset detail responses now include `tags`.

### `GET /api/tags?attachedOnly=true`
Returns only tags that have at least one preset attached.

## Why

The frontend now needs to:
- load only usable tags on the presets grid
- show real attached tags on the player page
- navigate from player tags back to the filtered presets grid
- support editor/discovery flows without hardcoded tag data

## Testing

- `.\mvnw.cmd -q "-Dtest=PresetControllerTests,PresetServiceTests,PresetControllerIntegrationTests" test`
- `.\mvnw.cmd -q "-Dtest=TagControllerTests,TagServiceTests,TagRepositoryIntegrationTest,TagControllerIntegrationTests" test`

## Notes

- existing tag creation behavior is unchanged
- existing preset-tag attach behavior is unchanged
- this PR does not add tag removal or authorization hardening
