### PR TITLE
93 replace displayname with firstname and lastname in the backend user model

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ See [docs/deployment.md](docs/deployment.md) for the expected reverse-proxy cont
 | `POST /api/auth/link/google`                | Public       | Link Google auth to an existing local account                                              |
 | `POST /api/auth/link/local`                 | Public       | Add local auth to an existing Google-backed account                                        |
 | `GET /api/users/me`                         | Bearer token | Return the current user profile                                                            |
-| `PUT /api/users/me`                         | Bearer token | Update the authenticated user's first and last name                                        |
+| `PUT /api/users/me`                         | Bearer token | Update the authenticated user's first name, last name, and display name                    |
 | `GET /api/tags`                             | Public       | List available tags                                                                        |
 | `POST /api/tags`                            | Public       | Create a tag                                                                               |
 | `POST /api/scenes`                         | Bearer token | Create a scene owned by the authenticated user and optionally finalize a staged thumbnail |
@@ -138,6 +138,16 @@ Successful auth and profile responses return the structured personal-name fields
 ```
 
 `displayName` remains the public-facing creator name used for scene attribution and other public surfaces.
+
+`PUT /api/users/me` accepts:
+
+```json
+{
+  "firstName": "Updated",
+  "lastName": "User",
+  "displayName": "Updated User"
+}
+```
 
 ## Repository Layout
 

--- a/README.md
+++ b/README.md
@@ -33,17 +33,19 @@ Windows PowerShell:
 
 ```powershell
 Copy-Item .env.example .env
-docker compose -f docker-compose.yml -f docker-compose.local.yml up --build
+docker compose down -v
+docker compose -f docker-compose.yml -f docker-compose.local.yml -f docker-compose.minio.yml up --build
 ```
 
 macOS/Linux:
 
 ```bash
 cp .env.example .env
-docker compose -f docker-compose.yml -f docker-compose.local.yml up --build
+docker compose down -v
+docker compose -f docker-compose.yml -f docker-compose.local.yml -f docker-compose.minio.yml up --build
 ```
 
-To run local self-hosted object storage instead of AWS S3, add the MinIO override:
+The local workflow currently expects the MinIO override because thumbnail storage configuration is required at startup:
 
 ```bash
 docker compose -f docker-compose.yml -f docker-compose.local.yml -f docker-compose.minio.yml up --build
@@ -95,6 +97,7 @@ See [docs/deployment.md](docs/deployment.md) for the expected reverse-proxy cont
 | `POST /api/auth/link/google`                | Public       | Link Google auth to an existing local account                                              |
 | `POST /api/auth/link/local`                 | Public       | Add local auth to an existing Google-backed account                                        |
 | `GET /api/users/me`                         | Bearer token | Return the current user profile                                                            |
+| `PUT /api/users/me`                         | Bearer token | Update the authenticated user's first and last name                                        |
 | `GET /api/tags`                             | Public       | List available tags                                                                        |
 | `POST /api/tags`                            | Public       | Create a tag                                                                               |
 | `POST /api/scenes`                         | Bearer token | Create a scene owned by the authenticated user and optionally finalize a staged thumbnail |
@@ -106,6 +109,35 @@ See [docs/deployment.md](docs/deployment.md) for the expected reverse-proxy cont
 | `GET /api/scenes/{id}`                     | Public       | Fetch a scene by id                                                                       |
 | `DELETE /api/scenes/{id}`                  | Bearer token | Delete a scene owned by the authenticated user                                            |
 | `GET /api/users/{id}/scenes`               | Bearer token | List scenes for a specific user                                                           |
+
+## Auth And Profile Contract
+
+`POST /api/auth/register` now accepts:
+
+```json
+{
+  "email": "new-user@example.com",
+  "password": "secret-value",
+  "firstName": "New",
+  "lastName": "User",
+  "displayName": "New User"
+}
+```
+
+Successful auth and profile responses return the structured personal-name fields alongside the public attribution name:
+
+```json
+{
+  "userId": 42,
+  "email": "new-user@example.com",
+  "firstName": "New",
+  "lastName": "User",
+  "displayName": "New User",
+  "authProvider": "LOCAL"
+}
+```
+
+`displayName` remains the public-facing creator name used for scene attribution and other public surfaces.
 
 ## Repository Layout
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -122,6 +122,8 @@ Those are backed by:
 
 Schema changes are migration-driven. The repo expects PostgreSQL and keeps Hibernate schema mode at `validate` for normal development.
 
+Within `users`, the backend now stores `first_name`, `last_name`, and `display_name`. `display_name` remains the public attribution field, while auth and profile flows expose all three values.
+
 ## External Boundary
 
 Google sign-in is isolated behind the `GoogleTokenVerifier` interface. The production implementation is `GoogleApiClientTokenVerifier`.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,28 +21,25 @@ Windows PowerShell:
 
 ```powershell
 Copy-Item .env.example .env
-docker compose -f docker-compose.yml -f docker-compose.local.yml up --build
+docker compose down -v
+docker compose -f docker-compose.yml -f docker-compose.local.yml -f docker-compose.minio.yml up --build
 ```
 
 macOS/Linux:
 
 ```bash
 cp .env.example .env
-docker compose -f docker-compose.yml -f docker-compose.local.yml up --build
+docker compose down -v
+docker compose -f docker-compose.yml -f docker-compose.local.yml -f docker-compose.minio.yml up --build
 ```
 
 This starts:
 
 - `postgres`: PostgreSQL 16
 - `backend`: the Spring Boot service from this repo
+- `minio` plus its bootstrap helper for local thumbnail storage
 
-To run local self-hosted object storage instead of AWS S3, add:
-
-```bash
-docker compose -f docker-compose.yml -f docker-compose.local.yml -f docker-compose.minio.yml up --build
-```
-
-That override uses the `MAGE_THUMBNAIL_MINIO_*` values in `.env.example`, so you do not need to replace your normal S3 settings just to switch locally.
+The MinIO override uses the `MAGE_THUMBNAIL_MINIO_*` values in `.env.example`, so you do not need to replace your normal S3 settings just to switch locally.
 
 The split is intentional:
 
@@ -77,6 +74,8 @@ Useful follow-up checks:
 - `GET /api/scenes/{id}`
 
 For endpoint behavior and auth requirements, use [operations.md](operations.md).
+
+The registration payload now includes `firstName`, `lastName`, and `displayName`. Auth and profile responses return all three fields, while `displayName` stays the public attribution name.
 
 ## Running Tests
 
@@ -114,8 +113,8 @@ Migration rules:
 If local schema state gets messy, the quickest reset is:
 
 ```bash
-docker compose -f docker-compose.yml -f docker-compose.local.yml down -v
-docker compose -f docker-compose.yml -f docker-compose.local.yml up --build
+docker compose -f docker-compose.yml -f docker-compose.local.yml -f docker-compose.minio.yml down -v
+docker compose -f docker-compose.yml -f docker-compose.local.yml -f docker-compose.minio.yml up --build
 ```
 
 ## Common Local Issues

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -30,13 +30,14 @@ Operationally important behavior:
 ## Start the Stack
 
 ```bash
-docker compose -f docker-compose.yml -f docker-compose.local.yml up --build
+docker compose -f docker-compose.yml -f docker-compose.local.yml -f docker-compose.minio.yml up --build
 ```
 
 Use the base file plus the local file for host access:
 
 - `docker-compose.yml`: deployment-friendly base definition
 - `docker-compose.local.yml`: local-only port publishing
+- `docker-compose.minio.yml`: local thumbnail storage configuration and MinIO services
 
 Useful log commands:
 
@@ -84,6 +85,7 @@ If this returns `503`, the app process is alive but not ready to serve traffic.
 | `POST /api/auth/link/google`                | Public       | Requires valid local credentials plus a valid Google ID token       |
 | `POST /api/auth/link/local`                 | Public       | Requires a valid Google ID token                                    |
 | `GET /api/users/me`                         | Bearer token | Current authenticated user                                          |
+| `PUT /api/users/me`                         | Bearer token | Updates the current user's first and last name                      |
 | `GET /api/tags`                             | Public       | Returns all tags in name order                                      |
 | `POST /api/tags`                            | Public       | Tag creation is currently public                                    |
 | `POST /api/scenes`                         | Bearer token | Creates an owned scene and optionally finalizes a staged thumbnail |
@@ -105,6 +107,9 @@ If this returns `503`, the app process is alive but not ready to serve traffic.
 - `POST /api/auth/google`: `201` or `200` on success, `401` for invalid token, `409` for collision or link-required cases
 - `POST /api/auth/link/google`: `200` on success, `401` for invalid local credentials, `409` for account conflicts
 - `POST /api/auth/link/local`: `200` on success, `401` for invalid Google token, `409` for incompatible account state
+- `PUT /api/users/me`: `200` on success, `400` for invalid first or last name, `401` without a valid bearer token
+
+Registration requests must include `firstName`, `lastName`, and `displayName`. Auth and profile responses return all three fields, and `displayName` remains the public attribution field used outside authenticated profile surfaces.
 
 ### Scenes and Tags
 
@@ -251,8 +256,8 @@ Rules:
 If local database state is corrupted or out of sync:
 
 ```bash
-docker compose -f docker-compose.yml -f docker-compose.local.yml down -v
-docker compose -f docker-compose.yml -f docker-compose.local.yml up --build
+docker compose -f docker-compose.yml -f docker-compose.local.yml -f docker-compose.minio.yml down -v
+docker compose -f docker-compose.yml -f docker-compose.local.yml -f docker-compose.minio.yml up --build
 ```
 
 This deletes the PostgreSQL volume and recreates the schema from migrations.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -85,7 +85,7 @@ If this returns `503`, the app process is alive but not ready to serve traffic.
 | `POST /api/auth/link/google`                | Public       | Requires valid local credentials plus a valid Google ID token       |
 | `POST /api/auth/link/local`                 | Public       | Requires a valid Google ID token                                    |
 | `GET /api/users/me`                         | Bearer token | Current authenticated user                                          |
-| `PUT /api/users/me`                         | Bearer token | Updates the current user's first and last name                      |
+| `PUT /api/users/me`                         | Bearer token | Updates the current user's first name, last name, and display name |
 | `GET /api/tags`                             | Public       | Returns all tags in name order                                      |
 | `POST /api/tags`                            | Public       | Tag creation is currently public                                    |
 | `POST /api/scenes`                         | Bearer token | Creates an owned scene and optionally finalizes a staged thumbnail |
@@ -107,7 +107,7 @@ If this returns `503`, the app process is alive but not ready to serve traffic.
 - `POST /api/auth/google`: `201` or `200` on success, `401` for invalid token, `409` for collision or link-required cases
 - `POST /api/auth/link/google`: `200` on success, `401` for invalid local credentials, `409` for account conflicts
 - `POST /api/auth/link/local`: `200` on success, `401` for invalid Google token, `409` for incompatible account state
-- `PUT /api/users/me`: `200` on success, `400` for invalid first or last name, `401` without a valid bearer token
+- `PUT /api/users/me`: `200` on success, `400` for invalid first name, last name, or display name, `401` without a valid bearer token
 
 Registration requests must include `firstName`, `lastName`, and `displayName`. Auth and profile responses return all three fields, and `displayName` remains the public attribution field used outside authenticated profile surfaces.
 

--- a/docs/tag-filter-testing/README.md
+++ b/docs/tag-filter-testing/README.md
@@ -53,7 +53,7 @@ Use the second terminal for the API requests below.
 $register = Invoke-RestMethod -Method Post `
   -Uri "http://localhost:8080/api/auth/register" `
   -ContentType "application/json" `
-  -Body '{"email":"filter-test@example.com","password":"test-password","displayName":"Filter Test User"}'
+  -Body '{"email":"filter-test@example.com","password":"test-password","firstName":"Filter","lastName":"Tester","displayName":"Filter Test User"}'
 ```
 
 ## 7. Log In and Save the Access Token
@@ -174,4 +174,3 @@ To remove containers afterward:
 ```powershell
 docker compose -f docker-compose.yml -f docker-compose.local.yml down
 ```
-

--- a/src/main/java/com/bdmage/mage_backend/controller/AuthController.java
+++ b/src/main/java/com/bdmage/mage_backend/controller/AuthController.java
@@ -59,6 +59,8 @@ public class AuthController {
 				.body(new GoogleAuthenticationResponse(
 						result.user().getId(),
 						result.user().getEmail(),
+						result.user().getFirstName(),
+						result.user().getLastName(),
 						result.user().getDisplayName(),
 						result.user().getAuthProvider().name(),
 						result.created(),
@@ -70,12 +72,16 @@ public class AuthController {
 		User user = this.registrationService.register(
 				request.email(),
 				request.password(),
+				request.firstName(),
+				request.lastName(),
 				request.displayName());
 
 		return ResponseEntity.status(HttpStatus.CREATED)
 				.body(new RegistrationResponse(
 						user.getId(),
 						user.getEmail(),
+						user.getFirstName(),
+						user.getLastName(),
 						user.getDisplayName(),
 						user.getAuthProvider().name()));
 	}
@@ -88,6 +94,8 @@ public class AuthController {
 		return ResponseEntity.ok(new LoginResponse(
 				user.getId(),
 				user.getEmail(),
+				user.getFirstName(),
+				user.getLastName(),
 				user.getDisplayName(),
 				user.getAuthProvider().name(),
 				accessToken));
@@ -116,6 +124,8 @@ public class AuthController {
 		return new AccountLinkResponse(
 				result.user().getId(),
 				result.user().getEmail(),
+				result.user().getFirstName(),
+				result.user().getLastName(),
 				result.user().getDisplayName(),
 				result.user().getAuthProvider().name(),
 				result.linked());

--- a/src/main/java/com/bdmage/mage_backend/controller/UserController.java
+++ b/src/main/java/com/bdmage/mage_backend/controller/UserController.java
@@ -3,15 +3,19 @@ package com.bdmage.mage_backend.controller;
 import java.util.List;
 import com.bdmage.mage_backend.config.AuthenticatedUserRequest;
 import com.bdmage.mage_backend.dto.SceneResponse;
+import com.bdmage.mage_backend.dto.UpdateUserProfileRequest;
 import com.bdmage.mage_backend.dto.UserProfileResponse;
 import com.bdmage.mage_backend.model.Scene;
 import com.bdmage.mage_backend.model.User;
 import com.bdmage.mage_backend.service.SceneService;
 import com.bdmage.mage_backend.service.SceneResponseFactory;
 import com.bdmage.mage_backend.service.UserProfileService;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -38,12 +42,31 @@ public class UserController {
 			@RequestAttribute(name = AuthenticatedUserRequest.USER_ID_ATTRIBUTE, required = false) Long authenticatedUserId) {
 		User user = this.userProfileService.getAuthenticatedUser(authenticatedUserId);
 
-		return ResponseEntity.ok(new UserProfileResponse(
+		return ResponseEntity.ok(toUserProfileResponse(user));
+	}
+
+	@PutMapping("/me")
+	ResponseEntity<UserProfileResponse> updateMe(
+			@RequestAttribute(name = AuthenticatedUserRequest.USER_ID_ATTRIBUTE, required = false) Long authenticatedUserId,
+			@Valid @RequestBody UpdateUserProfileRequest request) {
+		User user = this.userProfileService.updateAuthenticatedUserProfile(
+				authenticatedUserId,
+				request.firstName(),
+				request.lastName(),
+				request.displayName());
+
+		return ResponseEntity.ok(toUserProfileResponse(user));
+	}
+
+	private static UserProfileResponse toUserProfileResponse(User user) {
+		return new UserProfileResponse(
 				user.getId(),
 				user.getEmail(),
+				user.getFirstName(),
+				user.getLastName(),
 				user.getDisplayName(),
 				user.getAuthProvider().name(),
-				user.getCreatedAt()));
+				user.getCreatedAt());
 	}
 
 	@GetMapping("/{userId}/scenes")

--- a/src/main/java/com/bdmage/mage_backend/dto/AccountLinkResponse.java
+++ b/src/main/java/com/bdmage/mage_backend/dto/AccountLinkResponse.java
@@ -3,6 +3,8 @@ package com.bdmage.mage_backend.dto;
 public record AccountLinkResponse(
 		Long userId,
 		String email,
+		String firstName,
+		String lastName,
 		String displayName,
 		String authProvider,
 		boolean linked) {

--- a/src/main/java/com/bdmage/mage_backend/dto/GoogleAuthenticationResponse.java
+++ b/src/main/java/com/bdmage/mage_backend/dto/GoogleAuthenticationResponse.java
@@ -3,6 +3,8 @@ package com.bdmage.mage_backend.dto;
 public record GoogleAuthenticationResponse(
 		Long userId,
 		String email,
+		String firstName,
+		String lastName,
 		String displayName,
 		String authProvider,
 		boolean created,

--- a/src/main/java/com/bdmage/mage_backend/dto/LoginResponse.java
+++ b/src/main/java/com/bdmage/mage_backend/dto/LoginResponse.java
@@ -3,6 +3,8 @@ package com.bdmage.mage_backend.dto;
 public record LoginResponse(
 		Long userId,
 		String email,
+		String firstName,
+		String lastName,
 		String displayName,
 		String authProvider,
 		String accessToken) {

--- a/src/main/java/com/bdmage/mage_backend/dto/RegistrationResponse.java
+++ b/src/main/java/com/bdmage/mage_backend/dto/RegistrationResponse.java
@@ -3,6 +3,8 @@ package com.bdmage.mage_backend.dto;
 public record RegistrationResponse(
 		Long userId,
 		String email,
+		String firstName,
+		String lastName,
 		String displayName,
 		String authProvider) {
 }

--- a/src/main/java/com/bdmage/mage_backend/dto/UpdateUserProfileRequest.java
+++ b/src/main/java/com/bdmage/mage_backend/dto/UpdateUserProfileRequest.java
@@ -1,17 +1,9 @@
 package com.bdmage.mage_backend.dto;
 
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
-public record RegistrationRequest(
-		@NotBlank(message = "email must not be blank")
-		@Email(message = "email must be a well-formed email address")
-		@Size(max = 320, message = "email must be at most 320 characters")
-		String email,
-		@NotBlank(message = "password must not be blank")
-		@Size(max = 72, message = "password must be at most 72 characters")
-		String password,
+public record UpdateUserProfileRequest(
 		@NotBlank(message = "firstName must not be blank")
 		@Size(max = 100, message = "firstName must be at most 100 characters")
 		String firstName,

--- a/src/main/java/com/bdmage/mage_backend/dto/UserProfileResponse.java
+++ b/src/main/java/com/bdmage/mage_backend/dto/UserProfileResponse.java
@@ -5,6 +5,8 @@ import java.time.Instant;
 public record UserProfileResponse(
 		Long userId,
 		String email,
+		String firstName,
+		String lastName,
 		String displayName,
 		String authProvider,
 		Instant createdAt) {

--- a/src/main/java/com/bdmage/mage_backend/model/User.java
+++ b/src/main/java/com/bdmage/mage_backend/model/User.java
@@ -33,6 +33,12 @@ public class User {
 	@Column(name = "google_subject", length = 255)
 	private String googleSubject;
 
+	@Column(name = "first_name", nullable = false, length = 100)
+	private String firstName;
+
+	@Column(name = "last_name", nullable = false, length = 100)
+	private String lastName;
+
 	@Column(name = "display_name", nullable = false, length = 100)
 	private String displayName;
 
@@ -43,22 +49,49 @@ public class User {
 	}
 
 	public User(String email, String passwordHash, String displayName) {
-		this(email, AuthProvider.LOCAL, passwordHash, null, displayName);
+		this(email, passwordHash, displayName, "", displayName);
+	}
+
+	public User(String email, String passwordHash, String firstName, String lastName, String displayName) {
+		this(email, AuthProvider.LOCAL, passwordHash, null, firstName, lastName, displayName);
 	}
 
 	public static User google(String email, String googleSubject, String displayName) {
-		return new User(email, AuthProvider.GOOGLE, null, googleSubject, displayName);
+		return google(email, googleSubject, displayName, "", displayName);
+	}
+
+	public static User google(String email, String googleSubject, String firstName, String lastName, String displayName) {
+		return new User(email, AuthProvider.GOOGLE, null, googleSubject, firstName, lastName, displayName);
 	}
 
 	public static User localAndGoogle(String email, String passwordHash, String googleSubject, String displayName) {
-		return new User(email, AuthProvider.LOCAL_GOOGLE, passwordHash, googleSubject, displayName);
+		return localAndGoogle(email, passwordHash, googleSubject, displayName, "", displayName);
 	}
 
-	private User(String email, AuthProvider authProvider, String passwordHash, String googleSubject, String displayName) {
+	public static User localAndGoogle(
+			String email,
+			String passwordHash,
+			String googleSubject,
+			String firstName,
+			String lastName,
+			String displayName) {
+		return new User(email, AuthProvider.LOCAL_GOOGLE, passwordHash, googleSubject, firstName, lastName, displayName);
+	}
+
+	private User(
+			String email,
+			AuthProvider authProvider,
+			String passwordHash,
+			String googleSubject,
+			String firstName,
+			String lastName,
+			String displayName) {
 		this.email = Objects.requireNonNull(email, "email must not be null");
 		this.authProvider = Objects.requireNonNull(authProvider, "authProvider must not be null");
 		this.passwordHash = passwordHash;
 		this.googleSubject = googleSubject;
+		this.firstName = Objects.requireNonNull(firstName, "firstName must not be null");
+		this.lastName = Objects.requireNonNull(lastName, "lastName must not be null");
 		this.displayName = Objects.requireNonNull(displayName, "displayName must not be null");
 		validateProviderFields(authProvider, passwordHash, googleSubject);
 	}
@@ -110,6 +143,12 @@ public class User {
 		syncAuthProvider();
 	}
 
+	public void updateProfileName(String firstName, String lastName, String displayName) {
+		this.firstName = Objects.requireNonNull(firstName, "firstName must not be null");
+		this.lastName = Objects.requireNonNull(lastName, "lastName must not be null");
+		this.displayName = Objects.requireNonNull(displayName, "displayName must not be null");
+	}
+
 	private void syncAuthProvider() {
 		if (this.passwordHash != null && this.googleSubject != null) {
 			this.authProvider = AuthProvider.LOCAL_GOOGLE;
@@ -147,6 +186,14 @@ public class User {
 
 	public String getGoogleSubject() {
 		return this.googleSubject;
+	}
+
+	public String getFirstName() {
+		return this.firstName;
+	}
+
+	public String getLastName() {
+		return this.lastName;
 	}
 
 	public String getDisplayName() {

--- a/src/main/java/com/bdmage/mage_backend/service/GoogleAuthenticationService.java
+++ b/src/main/java/com/bdmage/mage_backend/service/GoogleAuthenticationService.java
@@ -50,10 +50,13 @@ public class GoogleAuthenticationService {
 					"A local account already exists for this email. Link Google through /api/auth/link/google after authenticating that local account.");
 		}
 
+		ResolvedNames resolvedNames = resolveNames(verifiedGoogleToken);
 		User googleUser = User.google(
 				normalisedEmail,
 				verifiedGoogleToken.subject(),
-				resolveDisplayName(verifiedGoogleToken));
+				resolvedNames.firstName(),
+				resolvedNames.lastName(),
+				resolvedNames.displayName());
 
 		try {
 			User savedUser = this.userRepository.saveAndFlush(googleUser);
@@ -98,7 +101,26 @@ public class GoogleAuthenticationService {
 			return verifiedGoogleToken.displayName().trim();
 		}
 
-		return verifiedGoogleToken.email();
+		return verifiedGoogleToken.email().trim();
+	}
+
+	private static ResolvedNames resolveNames(VerifiedGoogleToken verifiedGoogleToken) {
+		String resolvedDisplayName = resolveDisplayName(verifiedGoogleToken);
+
+		if (!StringUtils.hasText(verifiedGoogleToken.displayName())) {
+			return new ResolvedNames(resolvedDisplayName, "", resolvedDisplayName);
+		}
+
+		String normalizedFullName = resolvedDisplayName.replaceAll("\\s+", " ");
+		int firstSpace = normalizedFullName.indexOf(' ');
+		if (firstSpace < 0) {
+			return new ResolvedNames(normalizedFullName, "", normalizedFullName);
+		}
+
+		return new ResolvedNames(
+				normalizedFullName.substring(0, firstSpace),
+				normalizedFullName.substring(firstSpace + 1),
+				normalizedFullName);
 	}
 
 	private static String normalizeEmail(String email) {
@@ -107,5 +129,7 @@ public class GoogleAuthenticationService {
 
 	public record GoogleAuthenticationResult(User user, boolean created) {
 	}
-}
 
+	private record ResolvedNames(String firstName, String lastName, String displayName) {
+	}
+}

--- a/src/main/java/com/bdmage/mage_backend/service/RegistrationService.java
+++ b/src/main/java/com/bdmage/mage_backend/service/RegistrationService.java
@@ -24,8 +24,10 @@ public class RegistrationService {
 	}
 
 	@Transactional
-	public User register(String email, String plainPassword, String displayName) {
+	public User register(String email, String plainPassword, String firstName, String lastName, String displayName) {
 		String normalisedEmail = email.trim().toLowerCase(Locale.ROOT);
+		String trimmedFirstName = firstName.trim();
+		String trimmedLastName = lastName.trim();
 		String trimmedDisplayName = displayName.trim();
 
 		Optional<User> existingUser = this.userRepository.findByEmail(normalisedEmail);
@@ -39,8 +41,12 @@ public class RegistrationService {
 		}
 
 		String passwordHash = this.passwordHashingService.hash(plainPassword);
-		User newUser = new User(normalisedEmail, passwordHash, trimmedDisplayName);
+		User newUser = new User(
+				normalisedEmail,
+				passwordHash,
+				trimmedFirstName,
+				trimmedLastName,
+				trimmedDisplayName);
 		return this.userRepository.saveAndFlush(newUser);
 	}
 }
-

--- a/src/main/java/com/bdmage/mage_backend/service/UserProfileService.java
+++ b/src/main/java/com/bdmage/mage_backend/service/UserProfileService.java
@@ -26,4 +26,15 @@ public class UserProfileService {
 		return this.userRepository.findById(authenticatedUserId)
 				.orElseThrow(() -> new AuthenticationRequiredException(AUTHENTICATION_REQUIRED_MESSAGE));
 	}
+
+	@Transactional
+	public User updateAuthenticatedUserProfile(
+			Long authenticatedUserId,
+			String firstName,
+			String lastName,
+			String displayName) {
+		User user = getAuthenticatedUser(authenticatedUserId);
+		user.updateProfileName(firstName.trim(), lastName.trim(), displayName.trim());
+		return this.userRepository.saveAndFlush(user);
+	}
 }

--- a/src/main/resources/db/migration/V10__add_first_name_and_last_name_to_users.sql
+++ b/src/main/resources/db/migration/V10__add_first_name_and_last_name_to_users.sql
@@ -1,0 +1,14 @@
+ALTER TABLE users
+    ADD COLUMN first_name VARCHAR(100),
+    ADD COLUMN last_name VARCHAR(100);
+
+-- Preserve existing public attribution while backfilling structured name fields.
+UPDATE users
+SET first_name = display_name,
+    last_name = ''
+WHERE first_name IS NULL
+   OR last_name IS NULL;
+
+ALTER TABLE users
+    ALTER COLUMN first_name SET NOT NULL,
+    ALTER COLUMN last_name SET NOT NULL;

--- a/src/test/java/com/bdmage/mage_backend/AuthenticationTokensTableMigrationIntegrationTests.java
+++ b/src/test/java/com/bdmage/mage_backend/AuthenticationTokensTableMigrationIntegrationTests.java
@@ -72,13 +72,15 @@ class AuthenticationTokensTableMigrationIntegrationTests extends PostgresIntegra
 
 	private long insertLocalUser(Connection connection, String email) throws SQLException {
 		try (PreparedStatement statement = connection.prepareStatement("""
-				INSERT INTO users (email, password_hash, display_name)
-				VALUES (?, ?, ?)
+				INSERT INTO users (email, password_hash, display_name, first_name, last_name)
+				VALUES (?, ?, ?, ?, ?)
 				RETURNING id
 				""")) {
 			statement.setString(1, email);
 			statement.setString(2, "hashed-password-value");
 			statement.setString(3, "Token User");
+			statement.setString(4, "Token");
+			statement.setString(5, "User");
 
 			try (ResultSet resultSet = statement.executeQuery()) {
 				assertThat(resultSet.next()).isTrue();

--- a/src/test/java/com/bdmage/mage_backend/SceneTagsTableMigrationIntegrationTests.java
+++ b/src/test/java/com/bdmage/mage_backend/SceneTagsTableMigrationIntegrationTests.java
@@ -94,13 +94,15 @@ class SceneTagsTableMigrationIntegrationTests extends PostgresIntegrationTestSup
 
 	private long insertLocalUser(Connection connection, String email) throws SQLException {
 		try (PreparedStatement statement = connection.prepareStatement("""
-				INSERT INTO users (email, password_hash, display_name)
-				VALUES (?, ?, ?)
+				INSERT INTO users (email, password_hash, display_name, first_name, last_name)
+				VALUES (?, ?, ?, ?, ?)
 				RETURNING id
 				""")) {
 			statement.setString(1, email);
 			statement.setString(2, "hashed-password-value");
 			statement.setString(3, "Scene Tag Owner");
+			statement.setString(4, "Scene Tag");
+			statement.setString(5, "Owner");
 
 			try (ResultSet resultSet = statement.executeQuery()) {
 				assertThat(resultSet.next()).isTrue();

--- a/src/test/java/com/bdmage/mage_backend/ScenesTableMigrationIntegrationTests.java
+++ b/src/test/java/com/bdmage/mage_backend/ScenesTableMigrationIntegrationTests.java
@@ -81,13 +81,15 @@ class ScenesTableMigrationIntegrationTests extends PostgresIntegrationTestSuppor
 
 	private long insertLocalUser(Connection connection, String email) throws SQLException {
 		try (PreparedStatement statement = connection.prepareStatement("""
-				INSERT INTO users (email, password_hash, display_name)
-				VALUES (?, ?, ?)
+				INSERT INTO users (email, password_hash, display_name, first_name, last_name)
+				VALUES (?, ?, ?, ?, ?)
 				RETURNING id
 				""")) {
 			statement.setString(1, email);
 			statement.setString(2, "hashed-password-value");
 			statement.setString(3, "Scene Owner");
+			statement.setString(4, "Scene");
+			statement.setString(5, "Owner");
 
 			try (ResultSet resultSet = statement.executeQuery()) {
 				assertThat(resultSet.next()).isTrue();

--- a/src/test/java/com/bdmage/mage_backend/UsersTableMigrationIntegrationTests.java
+++ b/src/test/java/com/bdmage/mage_backend/UsersTableMigrationIntegrationTests.java
@@ -54,7 +54,9 @@ class UsersTableMigrationIntegrationTests extends PostgresIntegrationTestSupport
 					"display_name",
 					"created_at",
 					"auth_provider",
-					"google_subject");
+					"google_subject",
+					"first_name",
+					"last_name");
 		}
 	}
 
@@ -105,13 +107,15 @@ class UsersTableMigrationIntegrationTests extends PostgresIntegrationTestSupport
 
 	private Timestamp insertLocalUserAndReturnCreatedAt(Connection connection, String email) throws SQLException {
 		try (PreparedStatement statement = connection.prepareStatement("""
-				INSERT INTO users (email, password_hash, display_name)
-				VALUES (?, ?, ?)
+				INSERT INTO users (email, password_hash, display_name, first_name, last_name)
+				VALUES (?, ?, ?, ?, ?)
 				RETURNING created_at
 				""")) {
 			statement.setString(1, email);
 			statement.setString(2, "hashed-password-value");
 			statement.setString(3, "Test User");
+			statement.setString(4, "Test");
+			statement.setString(5, "User");
 
 			try (ResultSet resultSet = statement.executeQuery()) {
 				assertThat(resultSet.next()).isTrue();
@@ -123,13 +127,15 @@ class UsersTableMigrationIntegrationTests extends PostgresIntegrationTestSupport
 	private Timestamp insertGoogleUserAndReturnCreatedAt(Connection connection, String email, String googleSubject)
 			throws SQLException {
 		try (PreparedStatement statement = connection.prepareStatement("""
-				INSERT INTO users (email, auth_provider, password_hash, google_subject, display_name)
-				VALUES (?, 'GOOGLE', NULL, ?, ?)
+				INSERT INTO users (email, auth_provider, password_hash, google_subject, display_name, first_name, last_name)
+				VALUES (?, 'GOOGLE', NULL, ?, ?, ?, ?)
 				RETURNING created_at
 				""")) {
 			statement.setString(1, email);
 			statement.setString(2, googleSubject);
 			statement.setString(3, "Google User");
+			statement.setString(4, "Google");
+			statement.setString(5, "User");
 
 			try (ResultSet resultSet = statement.executeQuery()) {
 				assertThat(resultSet.next()).isTrue();
@@ -141,14 +147,16 @@ class UsersTableMigrationIntegrationTests extends PostgresIntegrationTestSupport
 	private Timestamp insertLinkedUserAndReturnCreatedAt(Connection connection, String email, String googleSubject)
 			throws SQLException {
 		try (PreparedStatement statement = connection.prepareStatement("""
-				INSERT INTO users (email, auth_provider, password_hash, google_subject, display_name)
-				VALUES (?, 'LOCAL_GOOGLE', ?, ?, ?)
+				INSERT INTO users (email, auth_provider, password_hash, google_subject, display_name, first_name, last_name)
+				VALUES (?, 'LOCAL_GOOGLE', ?, ?, ?, ?, ?)
 				RETURNING created_at
 				""")) {
 			statement.setString(1, email);
 			statement.setString(2, "hashed-password-value");
 			statement.setString(3, googleSubject);
 			statement.setString(4, "Linked User");
+			statement.setString(5, "Linked");
+			statement.setString(6, "User");
 
 			try (ResultSet resultSet = statement.executeQuery()) {
 				assertThat(resultSet.next()).isTrue();
@@ -159,46 +167,54 @@ class UsersTableMigrationIntegrationTests extends PostgresIntegrationTestSupport
 
 	private void insertGoogleUserWithoutSubject(Connection connection) throws SQLException {
 		try (PreparedStatement statement = connection.prepareStatement("""
-				INSERT INTO users (email, auth_provider, password_hash, display_name)
-				VALUES (?, 'GOOGLE', NULL, ?)
+				INSERT INTO users (email, auth_provider, password_hash, display_name, first_name, last_name)
+				VALUES (?, 'GOOGLE', NULL, ?, ?, ?)
 				""")) {
 			statement.setString(1, "google-missing-subject-" + System.nanoTime() + "@example.com");
 			statement.setString(2, "Google User");
+			statement.setString(3, "Google");
+			statement.setString(4, "User");
 			statement.executeUpdate();
 		}
 	}
 
 	private void insertLocalUserWithoutPasswordHash(Connection connection) throws SQLException {
 		try (PreparedStatement statement = connection.prepareStatement("""
-				INSERT INTO users (email, auth_provider, password_hash, display_name)
-				VALUES (?, 'LOCAL', NULL, ?)
+				INSERT INTO users (email, auth_provider, password_hash, display_name, first_name, last_name)
+				VALUES (?, 'LOCAL', NULL, ?, ?, ?)
 				""")) {
 			statement.setString(1, "local-missing-password-" + System.nanoTime() + "@example.com");
 			statement.setString(2, "Local User");
+			statement.setString(3, "Local");
+			statement.setString(4, "User");
 			statement.executeUpdate();
 		}
 	}
 
 	private void insertLinkedUserWithoutGoogleSubject(Connection connection) throws SQLException {
 		try (PreparedStatement statement = connection.prepareStatement("""
-				INSERT INTO users (email, auth_provider, password_hash, display_name)
-				VALUES (?, 'LOCAL_GOOGLE', ?, ?)
+				INSERT INTO users (email, auth_provider, password_hash, display_name, first_name, last_name)
+				VALUES (?, 'LOCAL_GOOGLE', ?, ?, ?, ?)
 				""")) {
 			statement.setString(1, "linked-missing-subject-" + System.nanoTime() + "@example.com");
 			statement.setString(2, "hashed-password-value");
 			statement.setString(3, "Linked User");
+			statement.setString(4, "Linked");
+			statement.setString(5, "User");
 			statement.executeUpdate();
 		}
 	}
 
 	private void insertLinkedUserWithoutPasswordHash(Connection connection) throws SQLException {
 		try (PreparedStatement statement = connection.prepareStatement("""
-				INSERT INTO users (email, auth_provider, password_hash, google_subject, display_name)
-				VALUES (?, 'LOCAL_GOOGLE', NULL, ?, ?)
+				INSERT INTO users (email, auth_provider, password_hash, google_subject, display_name, first_name, last_name)
+				VALUES (?, 'LOCAL_GOOGLE', NULL, ?, ?, ?, ?)
 				""")) {
 			statement.setString(1, "linked-missing-password-" + System.nanoTime() + "@example.com");
 			statement.setString(2, "linked-google-subject-" + System.nanoTime());
 			statement.setString(3, "Linked User");
+			statement.setString(4, "Linked");
+			statement.setString(5, "User");
 			statement.executeUpdate();
 		}
 	}

--- a/src/test/java/com/bdmage/mage_backend/controller/AccountLinkingControllerIntegrationTests.java
+++ b/src/test/java/com/bdmage/mage_backend/controller/AccountLinkingControllerIntegrationTests.java
@@ -44,13 +44,20 @@ class AccountLinkingControllerIntegrationTests extends PostgresIntegrationTestSu
 		String password = "password-" + uniqueSuffix;
 		String googleSubject = "google-subject-" + uniqueSuffix;
 
-		this.userRepository.saveAndFlush(new User(email, this.passwordHashingService.hash(password), "Local User"));
+		this.userRepository.saveAndFlush(new User(
+				email,
+				this.passwordHashingService.hash(password),
+				"Local",
+				"User",
+				"Local User"));
 
 		this.mockMvc.perform(post("/api/auth/link/google")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(googleLinkRequestBody(email, password, verifiedToken(googleSubject, email, "Google User"))))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.email").value(email))
+				.andExpect(jsonPath("$.firstName").value("Local"))
+				.andExpect(jsonPath("$.lastName").value("User"))
 				.andExpect(jsonPath("$.authProvider").value("LOCAL_GOOGLE"))
 				.andExpect(jsonPath("$.linked").value(true));
 
@@ -66,13 +73,15 @@ class AccountLinkingControllerIntegrationTests extends PostgresIntegrationTestSu
 		String password = "password-" + uniqueSuffix;
 		String googleSubject = "google-subject-" + uniqueSuffix;
 
-		this.userRepository.saveAndFlush(User.google(email, googleSubject, "Google User"));
+		this.userRepository.saveAndFlush(User.google(email, googleSubject, "Google", "User", "Google User"));
 
 		this.mockMvc.perform(post("/api/auth/link/local")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content(localLinkRequestBody(verifiedToken(googleSubject, email, "Google User"), password)))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.email").value(email))
+				.andExpect(jsonPath("$.firstName").value("Google"))
+				.andExpect(jsonPath("$.lastName").value("User"))
 				.andExpect(jsonPath("$.authProvider").value("LOCAL_GOOGLE"))
 				.andExpect(jsonPath("$.linked").value(true));
 
@@ -87,7 +96,12 @@ class AccountLinkingControllerIntegrationTests extends PostgresIntegrationTestSu
 		String email = "mismatch-link-" + uniqueSuffix + "@example.com";
 		String password = "password-" + uniqueSuffix;
 
-		this.userRepository.saveAndFlush(new User(email, this.passwordHashingService.hash(password), "Local User"));
+		this.userRepository.saveAndFlush(new User(
+				email,
+				this.passwordHashingService.hash(password),
+				"Local",
+				"User",
+				"Local User"));
 
 		this.mockMvc.perform(post("/api/auth/link/google")
 				.contentType(MediaType.APPLICATION_JSON)
@@ -113,4 +127,3 @@ class AccountLinkingControllerIntegrationTests extends PostgresIntegrationTestSu
 		return "{\"idToken\":\"" + idToken + "\",\"password\":\"" + password + "\"}";
 	}
 }
-

--- a/src/test/java/com/bdmage/mage_backend/controller/AuthControllerTests.java
+++ b/src/test/java/com/bdmage/mage_backend/controller/AuthControllerTests.java
@@ -68,7 +68,7 @@ class AuthControllerTests {
 
 	@Test
 	void googleAuthenticationReturnsCreatedUserWhenServiceCreatesAccount() throws Exception {
-		User googleUser = User.google("user@example.com", "google-subject-1", "Google User");
+		User googleUser = User.google("user@example.com", "google-subject-1", "Google", "User", "Google User");
 		ReflectionTestUtils.setField(googleUser, "id", 21L);
 
 		when(this.googleAuthenticationService.authenticate("valid-token"))
@@ -84,6 +84,8 @@ class AuthControllerTests {
 				.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
 				.andExpect(jsonPath("$.userId").value(21L))
 				.andExpect(jsonPath("$.email").value("user@example.com"))
+				.andExpect(jsonPath("$.firstName").value("Google"))
+				.andExpect(jsonPath("$.lastName").value("User"))
 				.andExpect(jsonPath("$.displayName").value("Google User"))
 				.andExpect(jsonPath("$.authProvider").value("GOOGLE"))
 				.andExpect(jsonPath("$.created").value(true))
@@ -92,7 +94,7 @@ class AuthControllerTests {
 
 	@Test
 	void googleAuthenticationReturnsOkWhenServiceReusesAccount() throws Exception {
-		User googleUser = User.google("user@example.com", "google-subject-2", "Google User");
+		User googleUser = User.google("user@example.com", "google-subject-2", "Google", "User", "Google User");
 		ReflectionTestUtils.setField(googleUser, "id", 22L);
 
 		when(this.googleAuthenticationService.authenticate("repeat-token"))
@@ -154,21 +156,23 @@ class AuthControllerTests {
 
 	@Test
 	void registrationReturnsCreatedLocalUser() throws Exception {
-		User localUser = new User("new-user@example.com", "hashed-password", "New User");
+		User localUser = new User("new-user@example.com", "hashed-password", "New", "User", "New User");
 		ReflectionTestUtils.setField(localUser, "id", 31L);
 
-		when(this.registrationService.register("new-user@example.com", "secret-value", "New User"))
+		when(this.registrationService.register("new-user@example.com", "secret-value", "New", "User", "New User"))
 				.thenReturn(localUser);
 
 		this.mockMvc.perform(post("/api/auth/register")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
-						{"email":"new-user@example.com","password":"secret-value","displayName":"New User"}
+						{"email":"new-user@example.com","password":"secret-value","firstName":"New","lastName":"User","displayName":"New User"}
 						"""))
 				.andExpect(status().isCreated())
 				.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
 				.andExpect(jsonPath("$.userId").value(31L))
 				.andExpect(jsonPath("$.email").value("new-user@example.com"))
+				.andExpect(jsonPath("$.firstName").value("New"))
+				.andExpect(jsonPath("$.lastName").value("User"))
 				.andExpect(jsonPath("$.displayName").value("New User"))
 				.andExpect(jsonPath("$.authProvider").value("LOCAL"))
 				.andExpect(jsonPath("$.password").doesNotExist())
@@ -180,25 +184,27 @@ class AuthControllerTests {
 		this.mockMvc.perform(post("/api/auth/register")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
-						{"email":" ","password":" ","displayName":" "}
+						{"email":" ","password":" ","firstName":" ","lastName":" ","displayName":" "}
 						"""))
 				.andExpect(status().isBadRequest())
 				.andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
 				.andExpect(jsonPath("$.details.email").value("email must not be blank"))
 				.andExpect(jsonPath("$.details.password").value("password must not be blank"))
+				.andExpect(jsonPath("$.details.firstName").value("firstName must not be blank"))
+				.andExpect(jsonPath("$.details.lastName").value("lastName must not be blank"))
 				.andExpect(jsonPath("$.details.displayName").value("displayName must not be blank"));
 	}
 
 	@Test
 	void registrationReturnsConflictWhenEmailAlreadyExists() throws Exception {
-		when(this.registrationService.register("existing@example.com", "secret-value", "Existing User"))
+		when(this.registrationService.register("existing@example.com", "secret-value", "Existing", "User", "Existing User"))
 				.thenThrow(new EmailAlreadyRegisteredException(
 						"Local authentication is already configured for this email."));
 
 		this.mockMvc.perform(post("/api/auth/register")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
-						{"email":"existing@example.com","password":"secret-value","displayName":"Existing User"}
+						{"email":"existing@example.com","password":"secret-value","firstName":"Existing","lastName":"User","displayName":"Existing User"}
 						"""))
 				.andExpect(status().isConflict())
 				.andExpect(jsonPath("$.code").value("EMAIL_ALREADY_REGISTERED"))
@@ -207,14 +213,14 @@ class AuthControllerTests {
 
 	@Test
 	void registrationReturnsConflictWhenExplicitLinkIsRequired() throws Exception {
-		when(this.registrationService.register("existing@example.com", "secret-value", "Existing User"))
+		when(this.registrationService.register("existing@example.com", "secret-value", "Existing", "User", "Existing User"))
 				.thenThrow(new AccountLinkRequiredException(
 						"A Google-backed account already exists for this email. Link local authentication through /api/auth/link/local after authenticating with Google."));
 
 		this.mockMvc.perform(post("/api/auth/register")
 				.contentType(MediaType.APPLICATION_JSON)
 				.content("""
-						{"email":"existing@example.com","password":"secret-value","displayName":"Existing User"}
+						{"email":"existing@example.com","password":"secret-value","firstName":"Existing","lastName":"User","displayName":"Existing User"}
 						"""))
 				.andExpect(status().isConflict())
 				.andExpect(jsonPath("$.code").value("ACCOUNT_LINK_REQUIRED"));
@@ -222,7 +228,7 @@ class AuthControllerTests {
 
 	@Test
 	void loginReturnsLocalUserWhenCredentialsAreValid() throws Exception {
-		User localUser = new User("local-user@example.com", "hashed-password", "Local User");
+		User localUser = new User("local-user@example.com", "hashed-password", "Local", "User", "Local User");
 		ReflectionTestUtils.setField(localUser, "id", 41L);
 
 		when(this.loginService.login("local-user@example.com", "secret-value"))
@@ -238,6 +244,8 @@ class AuthControllerTests {
 				.andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
 				.andExpect(jsonPath("$.userId").value(41L))
 				.andExpect(jsonPath("$.email").value("local-user@example.com"))
+				.andExpect(jsonPath("$.firstName").value("Local"))
+				.andExpect(jsonPath("$.lastName").value("User"))
 				.andExpect(jsonPath("$.displayName").value("Local User"))
 				.andExpect(jsonPath("$.authProvider").value("LOCAL"))
 				.andExpect(jsonPath("$.accessToken").value("issued-login-token"))
@@ -279,6 +287,8 @@ class AuthControllerTests {
 				"user@example.com",
 				"hashed-password",
 				"google-subject-1",
+				"Linked",
+				"User",
 				"Linked User");
 		ReflectionTestUtils.setField(linkedUser, "id", 51L);
 
@@ -292,6 +302,8 @@ class AuthControllerTests {
 						"""))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.userId").value(51L))
+				.andExpect(jsonPath("$.firstName").value("Linked"))
+				.andExpect(jsonPath("$.lastName").value("User"))
 				.andExpect(jsonPath("$.authProvider").value("LOCAL_GOOGLE"))
 				.andExpect(jsonPath("$.linked").value(true));
 	}
@@ -317,6 +329,8 @@ class AuthControllerTests {
 				"user@example.com",
 				"hashed-password",
 				"google-subject-2",
+				"Linked",
+				"User",
 				"Linked User");
 		ReflectionTestUtils.setField(linkedUser, "id", 52L);
 
@@ -330,8 +344,9 @@ class AuthControllerTests {
 						"""))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.userId").value(52L))
+				.andExpect(jsonPath("$.firstName").value("Linked"))
+				.andExpect(jsonPath("$.lastName").value("User"))
 				.andExpect(jsonPath("$.authProvider").value("LOCAL_GOOGLE"))
 				.andExpect(jsonPath("$.linked").value(false));
 	}
 }
-

--- a/src/test/java/com/bdmage/mage_backend/controller/GoogleAuthControllerIntegrationTests.java
+++ b/src/test/java/com/bdmage/mage_backend/controller/GoogleAuthControllerIntegrationTests.java
@@ -53,6 +53,8 @@ class GoogleAuthControllerIntegrationTests extends PostgresIntegrationTestSuppor
 				.content(requestBody(token)))
 				.andExpect(status().isCreated())
 				.andExpect(jsonPath("$.email").value(email))
+				.andExpect(jsonPath("$.firstName").value("Google"))
+				.andExpect(jsonPath("$.lastName").value("User"))
 				.andExpect(jsonPath("$.authProvider").value("GOOGLE"))
 				.andExpect(jsonPath("$.created").value(true))
 				.andExpect(jsonPath("$.accessToken").isNotEmpty());
@@ -126,4 +128,3 @@ class GoogleAuthControllerIntegrationTests extends PostgresIntegrationTestSuppor
 		}
 	}
 }
-

--- a/src/test/java/com/bdmage/mage_backend/controller/LoginControllerIntegrationTests.java
+++ b/src/test/java/com/bdmage/mage_backend/controller/LoginControllerIntegrationTests.java
@@ -43,6 +43,8 @@ class LoginControllerIntegrationTests extends PostgresIntegrationTestSupport {
 		this.userRepository.saveAndFlush(new User(
 				email,
 				this.passwordHashingService.hash(password),
+				"Login",
+				"User",
 				"Login User"));
 
 		this.mockMvc.perform(post("/api/auth/login")
@@ -50,6 +52,8 @@ class LoginControllerIntegrationTests extends PostgresIntegrationTestSupport {
 				.content(requestBody(email, password)))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.email").value(email))
+				.andExpect(jsonPath("$.firstName").value("Login"))
+				.andExpect(jsonPath("$.lastName").value("User"))
 				.andExpect(jsonPath("$.displayName").value("Login User"))
 				.andExpect(jsonPath("$.authProvider").value("LOCAL"))
 				.andExpect(jsonPath("$.accessToken").isNotEmpty())
@@ -97,4 +101,3 @@ class LoginControllerIntegrationTests extends PostgresIntegrationTestSupport {
 		return "{\"email\":\"" + email + "\",\"password\":\"" + password + "\"}";
 	}
 }
-

--- a/src/test/java/com/bdmage/mage_backend/controller/RegistrationControllerIntegrationTests.java
+++ b/src/test/java/com/bdmage/mage_backend/controller/RegistrationControllerIntegrationTests.java
@@ -40,19 +40,25 @@ class RegistrationControllerIntegrationTests extends PostgresIntegrationTestSupp
 		String uniqueSuffix = String.valueOf(System.nanoTime());
 		String email = "local-user-" + uniqueSuffix + "@example.com";
 		String password = "password-" + uniqueSuffix;
+		String firstName = "Local";
+		String lastName = "User";
 		String displayName = "Local User";
 
 		this.mockMvc.perform(post("/api/auth/register")
 				.contentType(MediaType.APPLICATION_JSON)
-				.content(requestBody(email, password, displayName)))
+				.content(requestBody(email, password, firstName, lastName, displayName)))
 				.andExpect(status().isCreated())
 				.andExpect(jsonPath("$.email").value(email))
+				.andExpect(jsonPath("$.firstName").value(firstName))
+				.andExpect(jsonPath("$.lastName").value(lastName))
 				.andExpect(jsonPath("$.displayName").value(displayName))
 				.andExpect(jsonPath("$.authProvider").value("LOCAL"))
 				.andExpect(jsonPath("$.password").doesNotExist())
 				.andExpect(jsonPath("$.passwordHash").doesNotExist());
 
 		User savedUser = this.userRepository.findByEmail(email).orElseThrow();
+		assertThat(savedUser.getFirstName()).isEqualTo(firstName);
+		assertThat(savedUser.getLastName()).isEqualTo(lastName);
 		assertThat(savedUser.getDisplayName()).isEqualTo(displayName);
 		assertThat(savedUser.getPasswordHash()).isNotEqualTo(password);
 		assertThat(this.passwordHashingService.matches(password, savedUser.getPasswordHash())).isTrue();
@@ -68,7 +74,7 @@ class RegistrationControllerIntegrationTests extends PostgresIntegrationTestSupp
 
 		this.mockMvc.perform(post("/api/auth/register")
 				.contentType(MediaType.APPLICATION_JSON)
-				.content(requestBody(email, password, "Local User")))
+				.content(requestBody(email, password, "Local", "User", "Local User")))
 				.andExpect(status().isConflict())
 				.andExpect(jsonPath("$.code").value("EMAIL_ALREADY_REGISTERED"))
 				.andExpect(jsonPath("$.message").value("Local authentication is already configured for this email."));
@@ -84,15 +90,24 @@ class RegistrationControllerIntegrationTests extends PostgresIntegrationTestSupp
 
 		this.mockMvc.perform(post("/api/auth/register")
 				.contentType(MediaType.APPLICATION_JSON)
-				.content(requestBody(email, password, "Local User")))
+				.content(requestBody(email, password, "Local", "User", "Local User")))
 				.andExpect(status().isConflict())
 				.andExpect(jsonPath("$.code").value("ACCOUNT_LINK_REQUIRED"))
 				.andExpect(jsonPath("$.message").value(
 						"A Google-backed account already exists for this email. Link local authentication through /api/auth/link/local after authenticating with Google."));
 	}
 
-	private static String requestBody(String email, String password, String displayName) {
-		return "{\"email\":\"" + email + "\",\"password\":\"" + password + "\",\"displayName\":\"" + displayName + "\"}";
+	private static String requestBody(
+			String email,
+			String password,
+			String firstName,
+			String lastName,
+			String displayName) {
+		return "{\"email\":\"" + email
+				+ "\",\"password\":\"" + password
+				+ "\",\"firstName\":\"" + firstName
+				+ "\",\"lastName\":\"" + lastName
+				+ "\",\"displayName\":\"" + displayName
+				+ "\"}";
 	}
 }
-

--- a/src/test/java/com/bdmage/mage_backend/controller/SceneControllerTests.java
+++ b/src/test/java/com/bdmage/mage_backend/controller/SceneControllerTests.java
@@ -536,7 +536,7 @@ class SceneControllerTests {
 	}
 
 	private User user(Long userId, String displayName) {
-		User user = new User("user-" + userId + "@example.com", "hashed-password", displayName);
+		User user = new User("user-" + userId + "@example.com", "hashed-password", displayName, "", displayName);
 		ReflectionTestUtils.setField(user, "id", userId);
 		return user;
 	}

--- a/src/test/java/com/bdmage/mage_backend/controller/UserControllerIntegrationTests.java
+++ b/src/test/java/com/bdmage/mage_backend/controller/UserControllerIntegrationTests.java
@@ -31,6 +31,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -82,6 +83,8 @@ class UserControllerIntegrationTests extends PostgresIntegrationTestSupport {
 		this.userRepository.saveAndFlush(new User(
 				email,
 				this.passwordHashingService.hash(password),
+				"Profile",
+				"Local",
 				"Profile Local User"));
 
 		MvcResult loginResult = this.mockMvc.perform(post("/api/auth/login")
@@ -97,6 +100,8 @@ class UserControllerIntegrationTests extends PostgresIntegrationTestSupport {
 				.header("Authorization", "Bearer " + accessToken))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.email").value(email))
+				.andExpect(jsonPath("$.firstName").value("Profile"))
+				.andExpect(jsonPath("$.lastName").value("Local"))
 				.andExpect(jsonPath("$.displayName").value("Profile Local User"))
 				.andExpect(jsonPath("$.authProvider").value("LOCAL"))
 				.andExpect(jsonPath("$.createdAt").isNotEmpty())
@@ -124,12 +129,54 @@ class UserControllerIntegrationTests extends PostgresIntegrationTestSupport {
 				.header("Authorization", "Bearer " + accessToken))
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.email").value(email))
+				.andExpect(jsonPath("$.firstName").value("Profile"))
+				.andExpect(jsonPath("$.lastName").value("Google User"))
 				.andExpect(jsonPath("$.displayName").value("Profile Google User"))
 				.andExpect(jsonPath("$.authProvider").value("GOOGLE"))
 				.andExpect(jsonPath("$.createdAt").isNotEmpty())
 				.andExpect(jsonPath("$.password").doesNotExist())
 				.andExpect(jsonPath("$.passwordHash").doesNotExist())
 				.andExpect(jsonPath("$.googleSubject").doesNotExist());
+	}
+
+	@Test
+	void updateMePersistsFirstAndLastNameForAuthenticatedUser() throws Exception {
+		String uniqueSuffix = String.valueOf(System.nanoTime());
+		String email = "profile-update-" + uniqueSuffix + "@example.com";
+		String password = "password-" + uniqueSuffix;
+
+		this.userRepository.saveAndFlush(new User(
+				email,
+				this.passwordHashingService.hash(password),
+				"Original",
+				"Name",
+				"Profile Local User"));
+
+		MvcResult loginResult = this.mockMvc.perform(post("/api/auth/login")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(loginRequestBody(email, password)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.accessToken").isNotEmpty())
+				.andReturn();
+
+		String accessToken = accessToken(loginResult);
+
+		this.mockMvc.perform(put("/api/users/me")
+				.header("Authorization", "Bearer " + accessToken)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+						{"firstName":"Updated","lastName":"Profile","displayName":"Updated Profile"}
+						"""))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.email").value(email))
+				.andExpect(jsonPath("$.firstName").value("Updated"))
+				.andExpect(jsonPath("$.lastName").value("Profile"))
+				.andExpect(jsonPath("$.displayName").value("Updated Profile"));
+
+		User savedUser = this.userRepository.findByEmail(email).orElseThrow();
+		assertThat(savedUser.getFirstName()).isEqualTo("Updated");
+		assertThat(savedUser.getLastName()).isEqualTo("Profile");
+		assertThat(savedUser.getDisplayName()).isEqualTo("Updated Profile");
 	}
 
 	@Test
@@ -257,4 +304,3 @@ class UserControllerIntegrationTests extends PostgresIntegrationTestSupport {
 		}
 	}
 }
-

--- a/src/test/java/com/bdmage/mage_backend/controller/UserControllerTests.java
+++ b/src/test/java/com/bdmage/mage_backend/controller/UserControllerTests.java
@@ -18,9 +18,11 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -47,7 +49,7 @@ class UserControllerTests {
 
 	@Test
 	void meReturnsAuthenticatedUserProfileWithoutSensitiveFields() throws Exception {
-		User user = new User("profile-user@example.com", "hashed-password", "Profile User");
+		User user = new User("profile-user@example.com", "hashed-password", "Profile", "User", "Profile User");
 		ReflectionTestUtils.setField(user, "id", 51L);
 		ReflectionTestUtils.setField(user, "createdAt", Instant.parse("2026-03-25T20:15:30Z"));
 
@@ -58,6 +60,8 @@ class UserControllerTests {
 				.andExpect(status().isOk())
 				.andExpect(jsonPath("$.userId").value(51L))
 				.andExpect(jsonPath("$.email").value("profile-user@example.com"))
+				.andExpect(jsonPath("$.firstName").value("Profile"))
+				.andExpect(jsonPath("$.lastName").value("User"))
 				.andExpect(jsonPath("$.displayName").value("Profile User"))
 				.andExpect(jsonPath("$.authProvider").value("LOCAL"))
 				.andExpect(jsonPath("$.createdAt").value("2026-03-25T20:15:30Z"))
@@ -75,6 +79,42 @@ class UserControllerTests {
 				.andExpect(status().isUnauthorized())
 				.andExpect(jsonPath("$.code").value("AUTHENTICATION_REQUIRED"))
 				.andExpect(jsonPath("$.message").value("Authentication is required."));
+	}
+
+	@Test
+	void updateMeReturnsUpdatedProfile() throws Exception {
+		User user = new User("profile-user@example.com", "hashed-password", "Updated", "Name", "Profile User");
+		ReflectionTestUtils.setField(user, "id", 51L);
+		ReflectionTestUtils.setField(user, "createdAt", Instant.parse("2026-03-25T20:15:30Z"));
+
+		when(this.userProfileService.updateAuthenticatedUserProfile(eq(51L), eq("Updated"), eq("Name"), eq("Updated Profile")))
+				.thenReturn(user);
+
+		this.mockMvc.perform(put("/api/users/me")
+				.requestAttr(AuthenticatedUserRequest.USER_ID_ATTRIBUTE, 51L)
+				.contentType("application/json")
+				.content("""
+						{"firstName":"Updated","lastName":"Name","displayName":"Updated Profile"}
+						"""))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.firstName").value("Updated"))
+				.andExpect(jsonPath("$.lastName").value("Name"))
+				.andExpect(jsonPath("$.displayName").value("Profile User"));
+	}
+
+	@Test
+	void updateMeRejectsInvalidRequestBody() throws Exception {
+		this.mockMvc.perform(put("/api/users/me")
+				.requestAttr(AuthenticatedUserRequest.USER_ID_ATTRIBUTE, 51L)
+				.contentType("application/json")
+				.content("""
+						{"firstName":" ","lastName":" ","displayName":" "}
+						"""))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+				.andExpect(jsonPath("$.details.firstName").value("firstName must not be blank"))
+				.andExpect(jsonPath("$.details.lastName").value("lastName must not be blank"))
+				.andExpect(jsonPath("$.details.displayName").value("displayName must not be blank"));
 	}
 
 	@Test
@@ -137,7 +177,7 @@ class UserControllerTests {
 	}
 
 	private User user(Long userId, String displayName) {
-		User user = new User("user-" + userId + "@example.com", "hashed-password", displayName);
+		User user = new User("user-" + userId + "@example.com", "hashed-password", displayName, "", displayName);
 		ReflectionTestUtils.setField(user, "id", userId);
 		return user;
 	}

--- a/src/test/java/com/bdmage/mage_backend/repository/UserRepositoryIntegrationTests.java
+++ b/src/test/java/com/bdmage/mage_backend/repository/UserRepositoryIntegrationTests.java
@@ -33,12 +33,24 @@ class UserRepositoryIntegrationTests extends PostgresIntegrationTestSupport {
 		String linkedEmail = "linked-user-" + System.nanoTime() + "@example.com";
 		String googleSubject = "google-subject-" + System.nanoTime();
 		String linkedGoogleSubject = "linked-google-subject-" + System.nanoTime();
-		User savedLocalUser = userRepository.saveAndFlush(new User(localEmail, "hashed-password-value", "Local User"));
-		User savedGoogleUser = userRepository.saveAndFlush(User.google(googleEmail, googleSubject, "Google User"));
+		User savedLocalUser = userRepository.saveAndFlush(new User(
+				localEmail,
+				"hashed-password-value",
+				"Local",
+				"User",
+				"Local User"));
+		User savedGoogleUser = userRepository.saveAndFlush(User.google(
+				googleEmail,
+				googleSubject,
+				"Google",
+				"User",
+				"Google User"));
 		User savedLinkedUser = userRepository.saveAndFlush(User.localAndGoogle(
 				linkedEmail,
 				"linked-password-hash",
 				linkedGoogleSubject,
+				"Linked",
+				"User",
 				"Linked User"));
 
 		entityManager.clear();
@@ -58,6 +70,8 @@ class UserRepositoryIntegrationTests extends PostgresIntegrationTestSupport {
 		assertThat(foundLocalUser.getAuthProvider()).isEqualTo(AuthProvider.LOCAL);
 		assertThat(foundLocalUser.getPasswordHash()).isEqualTo("hashed-password-value");
 		assertThat(foundLocalUser.getGoogleSubject()).isNull();
+		assertThat(foundLocalUser.getFirstName()).isEqualTo("Local");
+		assertThat(foundLocalUser.getLastName()).isEqualTo("User");
 		assertThat(foundLocalUser.getDisplayName()).isEqualTo("Local User");
 		assertThat(foundLocalUser.getCreatedAt()).isNotNull();
 
@@ -66,6 +80,8 @@ class UserRepositoryIntegrationTests extends PostgresIntegrationTestSupport {
 		assertThat(foundGoogleUserByEmail.getAuthProvider()).isEqualTo(AuthProvider.GOOGLE);
 		assertThat(foundGoogleUserByEmail.getPasswordHash()).isNull();
 		assertThat(foundGoogleUserByEmail.getGoogleSubject()).isEqualTo(googleSubject);
+		assertThat(foundGoogleUserByEmail.getFirstName()).isEqualTo("Google");
+		assertThat(foundGoogleUserByEmail.getLastName()).isEqualTo("User");
 		assertThat(foundGoogleUserByEmail.getDisplayName()).isEqualTo("Google User");
 		assertThat(foundGoogleUserByEmail.getCreatedAt()).isNotNull();
 
@@ -75,6 +91,8 @@ class UserRepositoryIntegrationTests extends PostgresIntegrationTestSupport {
 		assertThat(foundLinkedUserByEmail.getAuthProvider()).isEqualTo(AuthProvider.LOCAL_GOOGLE);
 		assertThat(foundLinkedUserByEmail.getPasswordHash()).isEqualTo("linked-password-hash");
 		assertThat(foundLinkedUserByEmail.getGoogleSubject()).isEqualTo(linkedGoogleSubject);
+		assertThat(foundLinkedUserByEmail.getFirstName()).isEqualTo("Linked");
+		assertThat(foundLinkedUserByEmail.getLastName()).isEqualTo("User");
 		assertThat(foundLinkedUserByEmail.getDisplayName()).isEqualTo("Linked User");
 		assertThat(foundLinkedUserByEmail.getCreatedAt()).isNotNull();
 		assertThat(foundLinkedUserBySubject.getId()).isEqualTo(savedLinkedUser.getId());

--- a/src/test/java/com/bdmage/mage_backend/service/GoogleAuthenticationServiceTests.java
+++ b/src/test/java/com/bdmage/mage_backend/service/GoogleAuthenticationServiceTests.java
@@ -37,7 +37,7 @@ class GoogleAuthenticationServiceTests {
 				"user@example.com",
 				true,
 				"Google User");
-		User savedUser = User.google("user@example.com", "google-subject-1", "Google User");
+		User savedUser = User.google("user@example.com", "google-subject-1", "Google", "User", "Google User");
 		ReflectionTestUtils.setField(savedUser, "id", 42L);
 
 		when(googleTokenVerifier.verify("valid-token")).thenReturn(Optional.of(verifiedGoogleToken));
@@ -51,6 +51,8 @@ class GoogleAuthenticationServiceTests {
 		assertThat(result.created()).isTrue();
 		assertThat(result.user().getId()).isEqualTo(42L);
 		assertThat(result.user().getEmail()).isEqualTo("user@example.com");
+		assertThat(result.user().getFirstName()).isEqualTo("Google");
+		assertThat(result.user().getLastName()).isEqualTo("User");
 		assertThat(result.user().getAuthProvider()).isEqualTo(AuthProvider.GOOGLE);
 		verify(userRepository).saveAndFlush(any(User.class));
 	}
@@ -68,7 +70,7 @@ class GoogleAuthenticationServiceTests {
 				"user@example.com",
 				true,
 				"Google User");
-		User existingUser = User.google("user@example.com", "google-subject-2", "Google User");
+		User existingUser = User.google("user@example.com", "google-subject-2", "Google", "User", "Google User");
 		ReflectionTestUtils.setField(existingUser, "id", 84L);
 
 		when(googleTokenVerifier.verify("repeat-token")).thenReturn(Optional.of(verifiedGoogleToken));
@@ -134,6 +136,34 @@ class GoogleAuthenticationServiceTests {
 	}
 
 	@Test
+	void fallsBackToEmailWhenGoogleDisplayNameIsMissing() {
+		GoogleTokenVerifier googleTokenVerifier = mock(GoogleTokenVerifier.class);
+		UserRepository userRepository = mock(UserRepository.class);
+		GoogleAuthenticationService googleAuthenticationService = new GoogleAuthenticationService(
+				googleTokenVerifier,
+				userRepository);
+
+		VerifiedGoogleToken verifiedGoogleToken = new VerifiedGoogleToken(
+				"google-subject-fallback",
+				"user@example.com",
+				true,
+				" ");
+		User savedUser = User.google("user@example.com", "google-subject-fallback", "user@example.com", "", "user@example.com");
+
+		when(googleTokenVerifier.verify("fallback-token")).thenReturn(Optional.of(verifiedGoogleToken));
+		when(userRepository.findByGoogleSubject("google-subject-fallback")).thenReturn(Optional.empty());
+		when(userRepository.findByEmail("user@example.com")).thenReturn(Optional.empty());
+		when(userRepository.saveAndFlush(any(User.class))).thenReturn(savedUser);
+
+		GoogleAuthenticationService.GoogleAuthenticationResult result = googleAuthenticationService.authenticate(
+				"fallback-token");
+
+		assertThat(result.user().getFirstName()).isEqualTo("user@example.com");
+		assertThat(result.user().getLastName()).isEmpty();
+		assertThat(result.user().getDisplayName()).isEqualTo("user@example.com");
+	}
+
+	@Test
 	void rejectsConflictsWithExistingGoogleAccountUsingSameEmail() {
 		GoogleTokenVerifier googleTokenVerifier = mock(GoogleTokenVerifier.class);
 		UserRepository userRepository = mock(UserRepository.class);
@@ -165,7 +195,7 @@ class GoogleAuthenticationServiceTests {
 				"user@example.com",
 				true,
 				"Google User");
-		User existingUser = User.google("user@example.com", "google-subject-5", "Google User");
+		User existingUser = User.google("user@example.com", "google-subject-5", "Google", "User", "Google User");
 		ReflectionTestUtils.setField(existingUser, "id", 128L);
 
 		when(googleTokenVerifier.verify("race-token")).thenReturn(Optional.of(verifiedGoogleToken));
@@ -181,4 +211,3 @@ class GoogleAuthenticationServiceTests {
 		assertThat(result.user().getId()).isEqualTo(128L);
 	}
 }
-

--- a/src/test/java/com/bdmage/mage_backend/service/RegistrationServiceTests.java
+++ b/src/test/java/com/bdmage/mage_backend/service/RegistrationServiceTests.java
@@ -30,7 +30,12 @@ class RegistrationServiceTests {
 		when(passwordHashingService.hash("plain-password")).thenReturn("hashed-password");
 		when(userRepository.saveAndFlush(any(User.class))).thenAnswer(invocation -> invocation.getArgument(0, User.class));
 
-		User registeredUser = registrationService.register(" User@Example.com ", "plain-password", " New User ");
+		User registeredUser = registrationService.register(
+				" User@Example.com ",
+				"plain-password",
+				" New ",
+				" User ",
+				" New User ");
 
 		ArgumentCaptor<User> userCaptor = ArgumentCaptor.forClass(User.class);
 		verify(userRepository).saveAndFlush(userCaptor.capture());
@@ -38,11 +43,15 @@ class RegistrationServiceTests {
 		User savedUser = userCaptor.getValue();
 		assertThat(savedUser.getEmail()).isEqualTo("user@example.com");
 		assertThat(savedUser.getPasswordHash()).isEqualTo("hashed-password");
+		assertThat(savedUser.getFirstName()).isEqualTo("New");
+		assertThat(savedUser.getLastName()).isEqualTo("User");
 		assertThat(savedUser.getDisplayName()).isEqualTo("New User");
 		assertThat(savedUser.getAuthProvider()).isEqualTo(AuthProvider.LOCAL);
 
 		assertThat(registeredUser.getEmail()).isEqualTo("user@example.com");
 		assertThat(registeredUser.getPasswordHash()).isEqualTo("hashed-password");
+		assertThat(registeredUser.getFirstName()).isEqualTo("New");
+		assertThat(registeredUser.getLastName()).isEqualTo("User");
 		assertThat(registeredUser.getDisplayName()).isEqualTo("New User");
 	}
 
@@ -55,7 +64,7 @@ class RegistrationServiceTests {
 		when(userRepository.findByEmail("user@example.com"))
 				.thenReturn(Optional.of(new User("user@example.com", "existing-hash", "Existing User")));
 
-		assertThatThrownBy(() -> registrationService.register("user@example.com", "plain-password", "New User"))
+		assertThatThrownBy(() -> registrationService.register("user@example.com", "plain-password", "New", "User", "New User"))
 				.isInstanceOf(EmailAlreadyRegisteredException.class)
 				.hasMessage("Local authentication is already configured for this email.");
 
@@ -72,7 +81,7 @@ class RegistrationServiceTests {
 		when(userRepository.findByEmail("user@example.com"))
 				.thenReturn(Optional.of(User.google("user@example.com", "google-subject-1", "Google User")));
 
-		assertThatThrownBy(() -> registrationService.register("user@example.com", "plain-password", "New User"))
+		assertThatThrownBy(() -> registrationService.register("user@example.com", "plain-password", "New", "User", "New User"))
 				.isInstanceOf(AccountLinkRequiredException.class)
 				.hasMessage(
 						"A Google-backed account already exists for this email. Link local authentication through /api/auth/link/local after authenticating with Google.");
@@ -81,4 +90,3 @@ class RegistrationServiceTests {
 		verify(userRepository, never()).saveAndFlush(any(User.class));
 	}
 }
-

--- a/src/test/java/com/bdmage/mage_backend/service/UserProfileServiceTests.java
+++ b/src/test/java/com/bdmage/mage_backend/service/UserProfileServiceTests.java
@@ -55,4 +55,26 @@ class UserProfileServiceTests {
 
 		verify(userRepository).findById(99L);
 	}
+
+	@Test
+	void updateAuthenticatedUserProfileTrimsAndPersistsNames() {
+		UserRepository userRepository = mock(UserRepository.class);
+		UserProfileService userProfileService = new UserProfileService(userRepository);
+		User user = new User("user@example.com", "hashed-password", "Profile", "User", "Profile User");
+
+		when(userRepository.findById(42L)).thenReturn(Optional.of(user));
+		when(userRepository.saveAndFlush(user)).thenReturn(user);
+
+		User updatedUser = userProfileService.updateAuthenticatedUserProfile(
+				42L,
+				" Updated ",
+				" Name ",
+				" Updated Profile ");
+
+		assertThat(updatedUser.getFirstName()).isEqualTo("Updated");
+		assertThat(updatedUser.getLastName()).isEqualTo("Name");
+		assertThat(updatedUser.getDisplayName()).isEqualTo("Updated Profile");
+		verify(userRepository).findById(42L);
+		verify(userRepository).saveAndFlush(user);
+	}
 }


### PR DESCRIPTION
## Summary

Closes #93

This PR expands the backend user model to store structured `firstName` and `lastName` fields while keeping `displayName` as the public-facing attribution name.

Included in this branch:
- add `first_name` and `last_name` to the `users` table with a migration that backfills existing users from `display_name`
- keep `display_name` in place for public attribution
- update the `User` model and related constructors/factory methods to support all three name fields
- update local registration to accept `firstName`, `lastName`, and `displayName`
- update auth, login, registration, account-linking, and profile responses to return all three fields
- add authenticated profile updates for `firstName`, `lastName`, and `displayName`
- update Google-auth user creation to resolve/store structured names while preserving `displayName`
- add request validation for `firstName`, `lastName`, and `displayName`
- update tests for migration, registration, login/profile responses, repository behavior, and linked-account flows
- update backend docs so the auth/profile contract includes `displayName` in the profile update route

## Behavior

- new local registrations persist `firstName`, `lastName`, and `displayName`
- existing users keep their current `displayName`
- `GET /api/users/me` returns `firstName`, `lastName`, and `displayName`
- `PUT /api/users/me` accepts `firstName`, `lastName`, and `displayName`
- public attribution on scenes/comments continues using `displayName`
- `LOCAL`, `GOOGLE`, and `LOCAL_GOOGLE` auth flows remain supported
- validation errors are returned clearly when `firstName`, `lastName`, or `displayName` is invalid

## Testing

Ran targeted backend tests covering migration, registration, auth, profile, Google auth, account linking, and repository behavior:

- `UsersTableMigrationIntegrationTests`
- `RegistrationControllerIntegrationTests`
- `UserControllerIntegrationTests`
- `AuthControllerTests`
- `GoogleAuthenticationServiceTests`
- `AccountLinkingControllerIntegrationTests`
- `LoginControllerIntegrationTests`
- `UserRepositoryIntegrationTests`
- `UserControllerTests`
- `RegistrationServiceTests`
- `UserProfileServiceTests`
