### PR TITLE
105 expose real engagement summary on preset detail

### DIFF
--- a/src/main/java/com/bdmage/mage_backend/config/AuthenticationInterceptor.java
+++ b/src/main/java/com/bdmage/mage_backend/config/AuthenticationInterceptor.java
@@ -21,6 +21,7 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
 	private static final List<String> PUBLIC_SCENE_READ_PATTERNS = List.of(
 			"/api/scenes",
 			"/api/scenes/{id}");
+	private static final String PUBLIC_SCENE_VIEW_PATTERN = "/api/scenes/{id}/views";
 	private static final AntPathMatcher PATH_MATCHER = new AntPathMatcher();
 
 	private final AuthenticationTokenService authenticationTokenService;
@@ -33,7 +34,8 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
 	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
 		// Scene discovery and public scene detail pages allow anonymous GET reads
 		// without opening write or owner-sensitive scene routes.
-		if (isPublicSceneReadRequest(request)) {
+		if (isOptionalAuthenticationRequest(request)) {
+			authenticatePublicReadIfBearerTokenPresent(request);
 			return true;
 		}
 
@@ -51,6 +53,25 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
 		String requestPath = pathWithinApplication(request);
 		return PUBLIC_SCENE_READ_PATTERNS.stream()
 				.anyMatch(pattern -> PATH_MATCHER.match(pattern, requestPath));
+	}
+
+	private static boolean isOptionalAuthenticationRequest(HttpServletRequest request) {
+		return isPublicSceneReadRequest(request) || isPublicSceneViewRequest(request);
+	}
+
+	private static boolean isPublicSceneViewRequest(HttpServletRequest request) {
+		return HttpMethod.POST.matches(request.getMethod())
+				&& PATH_MATCHER.match(PUBLIC_SCENE_VIEW_PATTERN, pathWithinApplication(request));
+	}
+
+	private void authenticatePublicReadIfBearerTokenPresent(HttpServletRequest request) {
+		String authorizationHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+		if (!StringUtils.hasText(authorizationHeader)) {
+			return;
+		}
+
+		User authenticatedUser = this.authenticationTokenService.authenticate(resolveBearerToken(request));
+		AuthenticatedUserRequest.authenticate(request, authenticatedUser);
 	}
 
 	private static String pathWithinApplication(HttpServletRequest request) {

--- a/src/main/java/com/bdmage/mage_backend/controller/SceneController.java
+++ b/src/main/java/com/bdmage/mage_backend/controller/SceneController.java
@@ -6,11 +6,15 @@ import com.bdmage.mage_backend.dto.AttachTagToSceneRequest;
 import com.bdmage.mage_backend.dto.CreateSceneRequest;
 import com.bdmage.mage_backend.dto.CreateSceneThumbnailUploadRequest;
 import com.bdmage.mage_backend.dto.FinalizeSceneThumbnailUploadRequest;
+import com.bdmage.mage_backend.dto.SceneDetailResponse;
+import com.bdmage.mage_backend.dto.SceneEngagementResponse;
 import com.bdmage.mage_backend.dto.SceneResponse;
 import com.bdmage.mage_backend.dto.SceneTagResponse;
 import com.bdmage.mage_backend.dto.PresignedThumbnailUploadResponse;
+import com.bdmage.mage_backend.dto.UpdateSceneVoteRequest;
 import com.bdmage.mage_backend.model.Scene;
 import com.bdmage.mage_backend.model.SceneTag;
+import com.bdmage.mage_backend.service.SceneEngagementService;
 import com.bdmage.mage_backend.service.SceneService;
 import com.bdmage.mage_backend.service.SceneResponseFactory;
 import jakarta.validation.Valid;
@@ -21,6 +25,7 @@ import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestAttribute;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -33,10 +38,15 @@ public class SceneController {
 
 	private final SceneService sceneService;
 	private final SceneResponseFactory sceneResponseFactory;
+	private final SceneEngagementService sceneEngagementService;
 
-	public SceneController(SceneService sceneService, SceneResponseFactory sceneResponseFactory) {
+	public SceneController(
+			SceneService sceneService,
+			SceneResponseFactory sceneResponseFactory,
+			SceneEngagementService sceneEngagementService) {
 		this.sceneService = sceneService;
 		this.sceneResponseFactory = sceneResponseFactory;
+		this.sceneEngagementService = sceneEngagementService;
 	}
 
 	@PostMapping
@@ -77,20 +87,63 @@ public class SceneController {
 	}
 
 	@GetMapping
-	ResponseEntity<List<SceneResponse>> getScenes(@RequestParam(required = false) String tag) {
+	ResponseEntity<List<SceneResponse>> getScenes(
+			@RequestAttribute(name = AuthenticatedUserRequest.USER_ID_ATTRIBUTE, required = false) Long authenticatedUserId,
+			@RequestParam(required = false) String tag) {
 		List<Scene> scenes = StringUtils.hasText(tag)
 				? this.sceneService.getScenesByTag(tag)
 				: this.sceneService.getAllScenes();
 
-		return ResponseEntity.ok(this.sceneResponseFactory.from(scenes));
+		return ResponseEntity.ok(this.sceneResponseFactory.from(scenes, authenticatedUserId));
 	}
 
 	@GetMapping("/{id}")
-	ResponseEntity<SceneResponse> getScene(@PathVariable Long id) {
+	ResponseEntity<SceneDetailResponse> getScene(
+			@RequestAttribute(name = AuthenticatedUserRequest.USER_ID_ATTRIBUTE, required = false) Long authenticatedUserId,
+			@PathVariable Long id) {
 		Scene scene = this.sceneService.getScene(id);
 		List<String> tagNames = this.sceneService.getTagNamesForScene(id);
 
-		return ResponseEntity.ok(this.sceneResponseFactory.from(scene, tagNames));
+		return ResponseEntity.ok(this.sceneResponseFactory.detailFrom(
+				scene,
+				tagNames,
+				this.sceneEngagementService.getSceneEngagement(id, authenticatedUserId)));
+	}
+
+	@PostMapping("/{id}/views")
+	ResponseEntity<SceneEngagementResponse> recordSceneView(
+			@RequestAttribute(name = AuthenticatedUserRequest.USER_ID_ATTRIBUTE, required = false) Long authenticatedUserId,
+			@PathVariable Long id) {
+		return ResponseEntity.ok(this.sceneEngagementService.recordSceneView(id, authenticatedUserId));
+	}
+
+	@PutMapping("/{id}/vote")
+	ResponseEntity<SceneEngagementResponse> setSceneVote(
+			@RequestAttribute(name = AuthenticatedUserRequest.USER_ID_ATTRIBUTE, required = false) Long authenticatedUserId,
+			@PathVariable Long id,
+			@Valid @RequestBody UpdateSceneVoteRequest request) {
+		return ResponseEntity.ok(this.sceneEngagementService.setSceneVote(id, authenticatedUserId, request.vote()));
+	}
+
+	@DeleteMapping("/{id}/vote")
+	ResponseEntity<SceneEngagementResponse> clearSceneVote(
+			@RequestAttribute(name = AuthenticatedUserRequest.USER_ID_ATTRIBUTE, required = false) Long authenticatedUserId,
+			@PathVariable Long id) {
+		return ResponseEntity.ok(this.sceneEngagementService.clearSceneVote(id, authenticatedUserId));
+	}
+
+	@PostMapping("/{id}/save")
+	ResponseEntity<SceneEngagementResponse> saveScene(
+			@RequestAttribute(name = AuthenticatedUserRequest.USER_ID_ATTRIBUTE, required = false) Long authenticatedUserId,
+			@PathVariable Long id) {
+		return ResponseEntity.ok(this.sceneEngagementService.saveScene(id, authenticatedUserId));
+	}
+
+	@DeleteMapping("/{id}/save")
+	ResponseEntity<SceneEngagementResponse> unsaveScene(
+			@RequestAttribute(name = AuthenticatedUserRequest.USER_ID_ATTRIBUTE, required = false) Long authenticatedUserId,
+			@PathVariable Long id) {
+		return ResponseEntity.ok(this.sceneEngagementService.unsaveScene(id, authenticatedUserId));
 	}
 
 	@PostMapping("/{id}/thumbnail/presign")

--- a/src/main/java/com/bdmage/mage_backend/controller/UserController.java
+++ b/src/main/java/com/bdmage/mage_backend/controller/UserController.java
@@ -75,6 +75,6 @@ public class UserController {
 			@RequestAttribute(name = AuthenticatedUserRequest.USER_ID_ATTRIBUTE, required = false) Long authenticatedUserId) {
 		List<Scene> scenes = this.sceneService.getScenesForUser(authenticatedUserId, userId);
 
-		return ResponseEntity.ok(this.sceneResponseFactory.from(scenes));
+		return ResponseEntity.ok(this.sceneResponseFactory.from(scenes, authenticatedUserId));
 	}
 }

--- a/src/main/java/com/bdmage/mage_backend/dto/SceneDetailResponse.java
+++ b/src/main/java/com/bdmage/mage_backend/dto/SceneDetailResponse.java
@@ -8,7 +8,7 @@ import com.bdmage.mage_backend.model.Scene;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-public record SceneResponse(
+public record SceneDetailResponse(
 		Long sceneId,
 		Long ownerUserId,
 		String creatorDisplayName,
@@ -24,20 +24,12 @@ public record SceneResponse(
 	private static final TypeReference<Map<String, Object>> SCENE_DATA_TYPE = new TypeReference<>() {
 	};
 
-	public static SceneResponse from(Scene scene, String creatorDisplayName) {
-		return from(scene, creatorDisplayName, List.of(), SceneEngagementResponse.empty());
-	}
-
-	public static SceneResponse from(Scene scene, String creatorDisplayName, List<String> tags) {
-		return from(scene, creatorDisplayName, tags, SceneEngagementResponse.empty());
-	}
-
-	public static SceneResponse from(
+	public static SceneDetailResponse from(
 			Scene scene,
 			String creatorDisplayName,
 			List<String> tags,
 			SceneEngagementResponse engagement) {
-		return new SceneResponse(
+		return new SceneDetailResponse(
 				scene.getId(),
 				scene.getOwnerUserId(),
 				creatorDisplayName,

--- a/src/main/java/com/bdmage/mage_backend/dto/SceneEngagementResponse.java
+++ b/src/main/java/com/bdmage/mage_backend/dto/SceneEngagementResponse.java
@@ -1,0 +1,42 @@
+package com.bdmage.mage_backend.dto;
+
+import com.bdmage.mage_backend.repository.SceneEngagementSummaryProjection;
+
+public record SceneEngagementResponse(
+		long views,
+		long upvotes,
+		long downvotes,
+		long saves,
+		String currentUserVote,
+		boolean currentUserSaved) {
+
+	public static SceneEngagementResponse from(SceneEngagementSummaryProjection summary) {
+		return new SceneEngagementResponse(
+				longValue(summary.getViews()),
+				longValue(summary.getUpvotes()),
+				longValue(summary.getDownvotes()),
+				longValue(summary.getSaves()),
+				currentUserVote(summary.getCurrentUserVoteValue()),
+				Boolean.TRUE.equals(summary.getCurrentUserSaved()));
+	}
+
+	public static SceneEngagementResponse empty() {
+		return new SceneEngagementResponse(0L, 0L, 0L, 0L, null, false);
+	}
+
+	private static long longValue(Number value) {
+		return value == null ? 0L : value.longValue();
+	}
+
+	private static String currentUserVote(Number value) {
+		if (value == null) {
+			return null;
+		}
+
+		return switch (value.intValue()) {
+			case 1 -> "up";
+			case -1 -> "down";
+			default -> null;
+		};
+	}
+}

--- a/src/main/java/com/bdmage/mage_backend/dto/UpdateSceneVoteRequest.java
+++ b/src/main/java/com/bdmage/mage_backend/dto/UpdateSceneVoteRequest.java
@@ -1,0 +1,10 @@
+package com.bdmage.mage_backend.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record UpdateSceneVoteRequest(
+		@NotBlank(message = "vote must not be blank")
+		@Pattern(regexp = "up|down", message = "vote must be up or down")
+		String vote) {
+}

--- a/src/main/java/com/bdmage/mage_backend/repository/SceneEngagementRepository.java
+++ b/src/main/java/com/bdmage/mage_backend/repository/SceneEngagementRepository.java
@@ -1,0 +1,73 @@
+package com.bdmage.mage_backend.repository;
+
+import com.bdmage.mage_backend.model.Scene;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+
+public interface SceneEngagementRepository extends Repository<Scene, Long> {
+
+	@Query(value = """
+			SELECT
+			  (SELECT COUNT(*) FROM scene_views svw WHERE svw.scene_id = :sceneId) AS views,
+			  (SELECT COUNT(*) FROM scene_votes sv WHERE sv.scene_id = :sceneId AND sv.vote_value = 1) AS upvotes,
+			  (SELECT COUNT(*) FROM scene_votes sv WHERE sv.scene_id = :sceneId AND sv.vote_value = -1) AS downvotes,
+			  (SELECT COUNT(*) FROM scene_saves ss WHERE ss.scene_id = :sceneId) AS saves,
+			  (SELECT sv.vote_value FROM scene_votes sv WHERE sv.scene_id = :sceneId AND sv.user_id = :currentUserId) AS "currentUserVoteValue",
+			  EXISTS(
+			    SELECT 1
+			    FROM scene_saves ss
+			    WHERE ss.scene_id = :sceneId
+			      AND ss.user_id = :currentUserId
+			  ) AS "currentUserSaved"
+			""", nativeQuery = true)
+	SceneEngagementSummaryProjection summarizeSceneEngagement(
+			@Param("sceneId") Long sceneId,
+			@Param("currentUserId") Long currentUserId);
+
+	@Modifying
+	@Query(value = """
+			INSERT INTO scene_views (scene_id, user_id)
+			VALUES (:sceneId, :userId)
+			""", nativeQuery = true)
+	void insertSceneView(@Param("sceneId") Long sceneId, @Param("userId") Long userId);
+
+	@Modifying
+	@Query(value = """
+			INSERT INTO scene_votes (scene_id, user_id, vote_value)
+			VALUES (:sceneId, :userId, :voteValue)
+			ON CONFLICT (scene_id, user_id)
+			DO UPDATE SET
+			  vote_value = EXCLUDED.vote_value,
+			  updated_at = CURRENT_TIMESTAMP
+			""", nativeQuery = true)
+	void upsertSceneVote(
+			@Param("sceneId") Long sceneId,
+			@Param("userId") Long userId,
+			@Param("voteValue") int voteValue);
+
+	@Modifying
+	@Query(value = """
+			DELETE FROM scene_votes
+			WHERE scene_id = :sceneId
+			  AND user_id = :userId
+			""", nativeQuery = true)
+	void deleteSceneVote(@Param("sceneId") Long sceneId, @Param("userId") Long userId);
+
+	@Modifying
+	@Query(value = """
+			INSERT INTO scene_saves (scene_id, user_id)
+			VALUES (:sceneId, :userId)
+			ON CONFLICT (scene_id, user_id) DO NOTHING
+			""", nativeQuery = true)
+	void insertSceneSave(@Param("sceneId") Long sceneId, @Param("userId") Long userId);
+
+	@Modifying
+	@Query(value = """
+			DELETE FROM scene_saves
+			WHERE scene_id = :sceneId
+			  AND user_id = :userId
+			""", nativeQuery = true)
+	void deleteSceneSave(@Param("sceneId") Long sceneId, @Param("userId") Long userId);
+}

--- a/src/main/java/com/bdmage/mage_backend/repository/SceneEngagementSummaryProjection.java
+++ b/src/main/java/com/bdmage/mage_backend/repository/SceneEngagementSummaryProjection.java
@@ -1,0 +1,16 @@
+package com.bdmage.mage_backend.repository;
+
+public interface SceneEngagementSummaryProjection {
+
+	Number getViews();
+
+	Number getUpvotes();
+
+	Number getDownvotes();
+
+	Number getSaves();
+
+	Number getCurrentUserVoteValue();
+
+	Boolean getCurrentUserSaved();
+}

--- a/src/main/java/com/bdmage/mage_backend/service/SceneEngagementService.java
+++ b/src/main/java/com/bdmage/mage_backend/service/SceneEngagementService.java
@@ -1,0 +1,97 @@
+package com.bdmage.mage_backend.service;
+
+import com.bdmage.mage_backend.dto.SceneEngagementResponse;
+import com.bdmage.mage_backend.exception.AuthenticationRequiredException;
+import com.bdmage.mage_backend.exception.SceneNotFoundException;
+import com.bdmage.mage_backend.repository.SceneEngagementRepository;
+import com.bdmage.mage_backend.repository.SceneEngagementSummaryProjection;
+import com.bdmage.mage_backend.repository.SceneRepository;
+import com.bdmage.mage_backend.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class SceneEngagementService {
+
+	private static final String AUTHENTICATION_REQUIRED_MESSAGE = "Authentication is required.";
+	private static final String SCENE_NOT_FOUND_MESSAGE = "Scene not found.";
+
+	private final SceneEngagementRepository sceneEngagementRepository;
+	private final SceneRepository sceneRepository;
+	private final UserRepository userRepository;
+
+	public SceneEngagementService(
+			SceneEngagementRepository sceneEngagementRepository,
+			SceneRepository sceneRepository,
+			UserRepository userRepository) {
+		this.sceneEngagementRepository = sceneEngagementRepository;
+		this.sceneRepository = sceneRepository;
+		this.userRepository = userRepository;
+	}
+
+	@Transactional(readOnly = true)
+	public SceneEngagementResponse getSceneEngagement(Long sceneId, Long currentUserId) {
+		SceneEngagementSummaryProjection summary = this.sceneEngagementRepository
+				.summarizeSceneEngagement(sceneId, currentUserId);
+		return summary != null ? SceneEngagementResponse.from(summary) : SceneEngagementResponse.empty();
+	}
+
+	@Transactional
+	public SceneEngagementResponse recordSceneView(Long sceneId, Long currentUserId) {
+		requireSceneExists(sceneId);
+		this.sceneEngagementRepository.insertSceneView(sceneId, currentUserId);
+		return getSceneEngagement(sceneId, currentUserId);
+	}
+
+	@Transactional
+	public SceneEngagementResponse setSceneVote(Long sceneId, Long currentUserId, String vote) {
+		requireAuthenticatedUser(currentUserId);
+		requireSceneExists(sceneId);
+		this.sceneEngagementRepository.upsertSceneVote(sceneId, currentUserId, voteValue(vote));
+		return getSceneEngagement(sceneId, currentUserId);
+	}
+
+	@Transactional
+	public SceneEngagementResponse clearSceneVote(Long sceneId, Long currentUserId) {
+		requireAuthenticatedUser(currentUserId);
+		requireSceneExists(sceneId);
+		this.sceneEngagementRepository.deleteSceneVote(sceneId, currentUserId);
+		return getSceneEngagement(sceneId, currentUserId);
+	}
+
+	@Transactional
+	public SceneEngagementResponse saveScene(Long sceneId, Long currentUserId) {
+		requireAuthenticatedUser(currentUserId);
+		requireSceneExists(sceneId);
+		this.sceneEngagementRepository.insertSceneSave(sceneId, currentUserId);
+		return getSceneEngagement(sceneId, currentUserId);
+	}
+
+	@Transactional
+	public SceneEngagementResponse unsaveScene(Long sceneId, Long currentUserId) {
+		requireAuthenticatedUser(currentUserId);
+		requireSceneExists(sceneId);
+		this.sceneEngagementRepository.deleteSceneSave(sceneId, currentUserId);
+		return getSceneEngagement(sceneId, currentUserId);
+	}
+
+	private void requireAuthenticatedUser(Long currentUserId) {
+		if (currentUserId == null || !this.userRepository.existsById(currentUserId)) {
+			throw new AuthenticationRequiredException(AUTHENTICATION_REQUIRED_MESSAGE);
+		}
+	}
+
+	private void requireSceneExists(Long sceneId) {
+		if (!this.sceneRepository.existsById(sceneId)) {
+			throw new SceneNotFoundException(SCENE_NOT_FOUND_MESSAGE);
+		}
+	}
+
+	private static int voteValue(String vote) {
+		return switch (vote) {
+			case "up" -> 1;
+			case "down" -> -1;
+			default -> throw new IllegalArgumentException("Unsupported scene vote: " + vote);
+		};
+	}
+}

--- a/src/main/java/com/bdmage/mage_backend/service/SceneResponseFactory.java
+++ b/src/main/java/com/bdmage/mage_backend/service/SceneResponseFactory.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.bdmage.mage_backend.dto.SceneDetailResponse;
+import com.bdmage.mage_backend.dto.SceneEngagementResponse;
 import com.bdmage.mage_backend.dto.SceneResponse;
 import com.bdmage.mage_backend.model.Scene;
 import com.bdmage.mage_backend.model.User;
@@ -16,27 +18,51 @@ public class SceneResponseFactory {
 	private static final String UNKNOWN_CREATOR_DISPLAY_NAME = "Unknown creator";
 
 	private final UserRepository userRepository;
+	private final SceneEngagementService sceneEngagementService;
 
-	public SceneResponseFactory(UserRepository userRepository) {
+	public SceneResponseFactory(UserRepository userRepository, SceneEngagementService sceneEngagementService) {
 		this.userRepository = userRepository;
+		this.sceneEngagementService = sceneEngagementService;
 	}
 
 	public SceneResponse from(Scene scene) {
-		return SceneResponse.from(scene, resolveCreatorDisplayName(scene));
+		return SceneResponse.from(scene, resolveCreatorDisplayName(scene), List.of(), resolveEngagement(scene, null));
 	}
 
 	public SceneResponse from(Scene scene, List<String> tags) {
-		return SceneResponse.from(scene, resolveCreatorDisplayName(scene), tags);
+		return SceneResponse.from(scene, resolveCreatorDisplayName(scene), tags, resolveEngagement(scene, null));
+	}
+
+	public SceneDetailResponse detailFrom(
+			Scene scene,
+			List<String> tags,
+			SceneEngagementResponse engagement) {
+		return SceneDetailResponse.from(scene, resolveCreatorDisplayName(scene), tags, engagement);
 	}
 
 	public List<SceneResponse> from(List<Scene> scenes) {
+		return from(scenes, null);
+	}
+
+	public List<SceneResponse> from(List<Scene> scenes, Long currentUserId) {
 		Map<Long, String> creatorDisplayNames = resolveCreatorDisplayNames(scenes);
 
 		return scenes.stream()
 				.map(scene -> SceneResponse.from(
 						scene,
-						creatorDisplayNames.getOrDefault(scene.getOwnerUserId(), UNKNOWN_CREATOR_DISPLAY_NAME)))
+						creatorDisplayNames.getOrDefault(scene.getOwnerUserId(), UNKNOWN_CREATOR_DISPLAY_NAME),
+						List.of(),
+						resolveEngagement(scene, currentUserId)))
 				.toList();
+	}
+
+	private SceneEngagementResponse resolveEngagement(Scene scene, Long currentUserId) {
+		if (scene.getId() == null) {
+			return SceneEngagementResponse.empty();
+		}
+
+		SceneEngagementResponse engagement = this.sceneEngagementService.getSceneEngagement(scene.getId(), currentUserId);
+		return engagement != null ? engagement : SceneEngagementResponse.empty();
 	}
 
 	private Map<Long, String> resolveCreatorDisplayNames(List<Scene> scenes) {

--- a/src/main/resources/db/migration/V12__create_scene_engagement_tables.sql
+++ b/src/main/resources/db/migration/V12__create_scene_engagement_tables.sql
@@ -1,0 +1,30 @@
+CREATE TABLE scene_views (
+  id BIGSERIAL PRIMARY KEY,
+  scene_id BIGINT NOT NULL REFERENCES scenes(id) ON DELETE CASCADE,
+  user_id BIGINT REFERENCES users(id) ON DELETE SET NULL,
+  viewed_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX scene_views_scene_id_idx ON scene_views (scene_id);
+CREATE INDEX scene_views_user_id_idx ON scene_views (user_id);
+
+CREATE TABLE scene_votes (
+  scene_id BIGINT NOT NULL REFERENCES scenes(id) ON DELETE CASCADE,
+  user_id BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  vote_value SMALLINT NOT NULL CHECK (vote_value IN (-1, 1)),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (scene_id, user_id)
+);
+
+CREATE INDEX scene_votes_scene_id_vote_value_idx ON scene_votes (scene_id, vote_value);
+CREATE INDEX scene_votes_user_id_idx ON scene_votes (user_id);
+
+CREATE TABLE scene_saves (
+  scene_id BIGINT NOT NULL REFERENCES scenes(id) ON DELETE CASCADE,
+  user_id BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (scene_id, user_id)
+);
+
+CREATE INDEX scene_saves_user_id_idx ON scene_saves (user_id);

--- a/src/test/java/com/bdmage/mage_backend/config/AuthenticationInterceptorTests.java
+++ b/src/test/java/com/bdmage/mage_backend/config/AuthenticationInterceptorTests.java
@@ -63,6 +63,24 @@ class AuthenticationInterceptorTests {
 	}
 
 	@Test
+	void preHandleAuthenticatesPublicApiSceneDetailRequestWhenBearerTokenIsPresent() {
+		AuthenticationTokenService authenticationTokenService = mock(AuthenticationTokenService.class);
+		AuthenticationInterceptor interceptor = new AuthenticationInterceptor(authenticationTokenService);
+		User user = new User("user@example.com", "hashed-password", "User");
+		ReflectionTestUtils.setField(user, "id", 21L);
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/scenes/15");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		request.addHeader("Authorization", "Bearer valid-token");
+		when(authenticationTokenService.authenticate("valid-token")).thenReturn(user);
+
+		assertThat(interceptor.preHandle(request, response, new Object())).isTrue();
+		assertThat(request.getAttribute(AuthenticatedUserRequest.USER_ATTRIBUTE)).isSameAs(user);
+		assertThat(request.getAttribute(AuthenticatedUserRequest.USER_ID_ATTRIBUTE)).isEqualTo(21L);
+		verify(authenticationTokenService).authenticate("valid-token");
+	}
+
+	@Test
 	void preHandleAllowsPublicApiSceneListRequestWithoutAuthenticationHeader() {
 		AuthenticationTokenService authenticationTokenService = mock(AuthenticationTokenService.class);
 		AuthenticationInterceptor interceptor = new AuthenticationInterceptor(authenticationTokenService);
@@ -73,6 +91,37 @@ class AuthenticationInterceptorTests {
 		assertThat(request.getAttribute(AuthenticatedUserRequest.USER_ATTRIBUTE)).isNull();
 		assertThat(request.getAttribute(AuthenticatedUserRequest.USER_ID_ATTRIBUTE)).isNull();
 		verifyNoInteractions(authenticationTokenService);
+	}
+
+	@Test
+	void preHandleAllowsPublicApiSceneViewRequestWithoutAuthenticationHeader() {
+		AuthenticationTokenService authenticationTokenService = mock(AuthenticationTokenService.class);
+		AuthenticationInterceptor interceptor = new AuthenticationInterceptor(authenticationTokenService);
+		MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/scenes/15/views");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		assertThat(interceptor.preHandle(request, response, new Object())).isTrue();
+		assertThat(request.getAttribute(AuthenticatedUserRequest.USER_ATTRIBUTE)).isNull();
+		assertThat(request.getAttribute(AuthenticatedUserRequest.USER_ID_ATTRIBUTE)).isNull();
+		verifyNoInteractions(authenticationTokenService);
+	}
+
+	@Test
+	void preHandleAuthenticatesPublicApiSceneViewRequestWhenBearerTokenIsPresent() {
+		AuthenticationTokenService authenticationTokenService = mock(AuthenticationTokenService.class);
+		AuthenticationInterceptor interceptor = new AuthenticationInterceptor(authenticationTokenService);
+		User user = new User("user@example.com", "hashed-password", "User");
+		ReflectionTestUtils.setField(user, "id", 21L);
+		MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/scenes/15/views");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		request.addHeader("Authorization", "Bearer valid-token");
+		when(authenticationTokenService.authenticate("valid-token")).thenReturn(user);
+
+		assertThat(interceptor.preHandle(request, response, new Object())).isTrue();
+		assertThat(request.getAttribute(AuthenticatedUserRequest.USER_ATTRIBUTE)).isSameAs(user);
+		assertThat(request.getAttribute(AuthenticatedUserRequest.USER_ID_ATTRIBUTE)).isEqualTo(21L);
+		verify(authenticationTokenService).authenticate("valid-token");
 	}
 
 	@Test

--- a/src/test/java/com/bdmage/mage_backend/controller/SceneControllerIntegrationTests.java
+++ b/src/test/java/com/bdmage/mage_backend/controller/SceneControllerIntegrationTests.java
@@ -19,6 +19,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
 import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
@@ -30,6 +31,7 @@ import static org.hamcrest.Matchers.hasItems;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -59,6 +61,9 @@ class SceneControllerIntegrationTests extends PostgresIntegrationTestSupport {
 
 	@Autowired
 	private PasswordHashingService passwordHashingService;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
 
 	@Test
 	void createSceneReturnsUnauthorizedWhenRequestHasNoAuthenticationHeader() throws Exception {
@@ -437,6 +442,19 @@ class SceneControllerIntegrationTests extends PostgresIntegrationTestSupport {
 		Tag ambientTag = this.tagRepository.saveAndFlush(new Tag(ambientTagName));
 		this.sceneTagRepository.saveAndFlush(new SceneTag(savedScene.getId(), showcaseTag.getId()));
 		this.sceneTagRepository.saveAndFlush(new SceneTag(savedScene.getId(), ambientTag.getId()));
+		User upvoter = this.userRepository.saveAndFlush(new User(
+				"public-upvoter-" + uniqueSuffix + "@example.com",
+				this.passwordHashingService.hash("unused-upvoter-password-" + uniqueSuffix),
+				"Public Upvoter"));
+		User downvoter = this.userRepository.saveAndFlush(new User(
+				"public-downvoter-" + uniqueSuffix + "@example.com",
+				this.passwordHashingService.hash("unused-downvoter-password-" + uniqueSuffix),
+				"Public Downvoter"));
+		insertSceneView(savedScene.getId(), null);
+		insertSceneView(savedScene.getId(), upvoter.getId());
+		insertSceneVote(savedScene.getId(), upvoter.getId(), 1);
+		insertSceneVote(savedScene.getId(), downvoter.getId(), -1);
+		insertSceneSave(savedScene.getId(), upvoter.getId());
 
 		this.mockMvc.perform(get("/api/scenes/" + savedScene.getId())
 				.contentType(MediaType.APPLICATION_JSON))
@@ -451,7 +469,13 @@ class SceneControllerIntegrationTests extends PostgresIntegrationTestSupport {
 				.andExpect(jsonPath("$.thumbnailRef").value("thumbnails/scene-1.png"))
 				.andExpect(jsonPath("$.createdAt").isNotEmpty())
 				.andExpect(jsonPath("$.tags[0]").value(ambientTagName))
-				.andExpect(jsonPath("$.tags[1]").value(showcaseTagName));
+				.andExpect(jsonPath("$.tags[1]").value(showcaseTagName))
+				.andExpect(jsonPath("$.engagement.views").value(2L))
+				.andExpect(jsonPath("$.engagement.upvotes").value(1L))
+				.andExpect(jsonPath("$.engagement.downvotes").value(1L))
+				.andExpect(jsonPath("$.engagement.saves").value(1L))
+				.andExpect(jsonPath("$.engagement.currentUserVote").doesNotExist())
+				.andExpect(jsonPath("$.engagement.currentUserSaved").value(false));
 	}
 
 	@Test
@@ -486,6 +510,17 @@ class SceneControllerIntegrationTests extends PostgresIntegrationTestSupport {
 		Tag ambientTag = this.tagRepository.saveAndFlush(new Tag(ambientTagName));
 		this.sceneTagRepository.saveAndFlush(new SceneTag(savedScene.getId(), showcaseTag.getId()));
 		this.sceneTagRepository.saveAndFlush(new SceneTag(savedScene.getId(), ambientTag.getId()));
+		User otherUser = this.userRepository.saveAndFlush(new User(
+				"get-scene-other-" + uniqueSuffix + "@example.com",
+				this.passwordHashingService.hash("unused-other-password-" + uniqueSuffix),
+				"Get Scene Other User"));
+		insertSceneView(savedScene.getId(), null);
+		insertSceneView(savedScene.getId(), savedUser.getId());
+		insertSceneView(savedScene.getId(), otherUser.getId());
+		insertSceneVote(savedScene.getId(), savedUser.getId(), -1);
+		insertSceneVote(savedScene.getId(), otherUser.getId(), 1);
+		insertSceneSave(savedScene.getId(), savedUser.getId());
+		insertSceneSave(savedScene.getId(), otherUser.getId());
 
 		this.mockMvc.perform(get("/api/scenes/" + savedScene.getId())
 				.header("Authorization", "Bearer " + accessToken)
@@ -501,7 +536,132 @@ class SceneControllerIntegrationTests extends PostgresIntegrationTestSupport {
 				.andExpect(jsonPath("$.thumbnailRef").value("thumbnails/scene-1.png"))
 				.andExpect(jsonPath("$.createdAt").isNotEmpty())
 				.andExpect(jsonPath("$.tags[0]").value(ambientTagName))
-				.andExpect(jsonPath("$.tags[1]").value(showcaseTagName));
+				.andExpect(jsonPath("$.tags[1]").value(showcaseTagName))
+				.andExpect(jsonPath("$.engagement.views").value(3L))
+				.andExpect(jsonPath("$.engagement.upvotes").value(1L))
+				.andExpect(jsonPath("$.engagement.downvotes").value(1L))
+				.andExpect(jsonPath("$.engagement.saves").value(2L))
+				.andExpect(jsonPath("$.engagement.currentUserVote").value("down"))
+				.andExpect(jsonPath("$.engagement.currentUserSaved").value(true));
+	}
+
+	@Test
+	void getSceneReturnsZeroEngagementForPublicRequestWhenSceneHasNoEngagementRows() throws Exception {
+		String uniqueSuffix = String.valueOf(System.nanoTime());
+		String email = "zero-engagement-scene-user-" + uniqueSuffix + "@example.com";
+
+		User savedUser = this.userRepository.saveAndFlush(new User(
+				email,
+				this.passwordHashingService.hash("unused-password-" + uniqueSuffix),
+				"Zero Engagement Scene User"));
+		Scene savedScene = this.sceneRepository.saveAndFlush(new Scene(
+				savedUser.getId(),
+				"Silent Glow",
+				this.objectMapper.readTree("""
+						{"visualizer":{"shader":"nebula"}}
+						""")));
+
+		this.mockMvc.perform(get("/api/scenes/" + savedScene.getId())
+				.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.sceneId").value(savedScene.getId()))
+				.andExpect(jsonPath("$.engagement.views").value(0L))
+				.andExpect(jsonPath("$.engagement.upvotes").value(0L))
+				.andExpect(jsonPath("$.engagement.downvotes").value(0L))
+				.andExpect(jsonPath("$.engagement.saves").value(0L))
+				.andExpect(jsonPath("$.engagement.currentUserVote").doesNotExist())
+				.andExpect(jsonPath("$.engagement.currentUserSaved").value(false));
+	}
+
+	@Test
+	void recordSceneViewPersistsAnonymousViewAndReturnsUpdatedEngagement() throws Exception {
+		String uniqueSuffix = String.valueOf(System.nanoTime());
+		User savedUser = this.userRepository.saveAndFlush(new User(
+				"view-scene-user-" + uniqueSuffix + "@example.com",
+				this.passwordHashingService.hash("unused-password-" + uniqueSuffix),
+				"View Scene User"));
+		Scene savedScene = this.sceneRepository.saveAndFlush(new Scene(
+				savedUser.getId(),
+				"View Count Glow",
+				this.objectMapper.readTree("""
+						{"visualizer":{"shader":"nebula"}}
+						""")));
+
+		this.mockMvc.perform(post("/api/scenes/" + savedScene.getId() + "/views")
+				.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.views").value(1L))
+				.andExpect(jsonPath("$.upvotes").value(0L))
+				.andExpect(jsonPath("$.downvotes").value(0L))
+				.andExpect(jsonPath("$.saves").value(0L))
+				.andExpect(jsonPath("$.currentUserVote").doesNotExist())
+				.andExpect(jsonPath("$.currentUserSaved").value(false));
+
+		this.mockMvc.perform(get("/api/scenes/" + savedScene.getId())
+				.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.engagement.views").value(1L));
+	}
+
+	@Test
+	void authenticatedUserCanVoteAndSaveSceneAndClearBothStates() throws Exception {
+		String uniqueSuffix = String.valueOf(System.nanoTime());
+		String email = "engagement-user-" + uniqueSuffix + "@example.com";
+		String password = "password-" + uniqueSuffix;
+
+		User savedUser = this.userRepository.saveAndFlush(new User(
+				email,
+				this.passwordHashingService.hash(password),
+				"Engagement User"));
+		Scene savedScene = this.sceneRepository.saveAndFlush(new Scene(
+				savedUser.getId(),
+				"Engagement Glow",
+				this.objectMapper.readTree("""
+						{"visualizer":{"shader":"nebula"}}
+						""")));
+
+		String accessToken = accessToken(this.mockMvc.perform(post("/api/auth/login")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(loginRequestBody(email, password)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.accessToken").isNotEmpty())
+				.andReturn());
+
+		this.mockMvc.perform(put("/api/scenes/" + savedScene.getId() + "/vote")
+				.header("Authorization", "Bearer " + accessToken)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+						{"vote":"up"}
+						"""))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.upvotes").value(1L))
+				.andExpect(jsonPath("$.downvotes").value(0L))
+				.andExpect(jsonPath("$.currentUserVote").value("up"))
+				.andExpect(jsonPath("$.currentUserSaved").value(false));
+
+		this.mockMvc.perform(post("/api/scenes/" + savedScene.getId() + "/save")
+				.header("Authorization", "Bearer " + accessToken)
+				.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.saves").value(1L))
+				.andExpect(jsonPath("$.currentUserVote").value("up"))
+				.andExpect(jsonPath("$.currentUserSaved").value(true));
+
+		this.mockMvc.perform(delete("/api/scenes/" + savedScene.getId() + "/vote")
+				.header("Authorization", "Bearer " + accessToken)
+				.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.upvotes").value(0L))
+				.andExpect(jsonPath("$.currentUserVote").doesNotExist())
+				.andExpect(jsonPath("$.currentUserSaved").value(true));
+
+		this.mockMvc.perform(delete("/api/scenes/" + savedScene.getId() + "/save")
+				.header("Authorization", "Bearer " + accessToken)
+				.contentType(MediaType.APPLICATION_JSON))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.saves").value(0L))
+				.andExpect(jsonPath("$.currentUserVote").doesNotExist())
+				.andExpect(jsonPath("$.currentUserSaved").value(false));
 	}
 
 	@Test
@@ -653,5 +813,27 @@ class SceneControllerIntegrationTests extends PostgresIntegrationTestSupport {
 				.matcher(result.getResponse().getContentAsString());
 		assertThat(matcher.find()).isTrue();
 		return Long.valueOf(matcher.group(1));
+	}
+
+	private void insertSceneView(Long sceneId, Long userId) {
+		this.jdbcTemplate.update(
+				"INSERT INTO scene_views (scene_id, user_id) VALUES (?, ?)",
+				sceneId,
+				userId);
+	}
+
+	private void insertSceneVote(Long sceneId, Long userId, int voteValue) {
+		this.jdbcTemplate.update(
+				"INSERT INTO scene_votes (scene_id, user_id, vote_value) VALUES (?, ?, ?)",
+				sceneId,
+				userId,
+				voteValue);
+	}
+
+	private void insertSceneSave(Long sceneId, Long userId) {
+		this.jdbcTemplate.update(
+				"INSERT INTO scene_saves (scene_id, user_id) VALUES (?, ?)",
+				sceneId,
+				userId);
 	}
 }

--- a/src/test/java/com/bdmage/mage_backend/controller/SceneControllerTests.java
+++ b/src/test/java/com/bdmage/mage_backend/controller/SceneControllerTests.java
@@ -14,10 +14,12 @@ import com.bdmage.mage_backend.exception.SceneNotFoundException;
 import com.bdmage.mage_backend.exception.SceneOwnershipRequiredException;
 import com.bdmage.mage_backend.exception.SceneTagAlreadyExistsException;
 import com.bdmage.mage_backend.exception.TagNotFoundException;
+import com.bdmage.mage_backend.dto.SceneEngagementResponse;
 import com.bdmage.mage_backend.model.Scene;
 import com.bdmage.mage_backend.model.SceneTag;
 import com.bdmage.mage_backend.model.User;
 import com.bdmage.mage_backend.repository.UserRepository;
+import com.bdmage.mage_backend.service.SceneEngagementService;
 import com.bdmage.mage_backend.service.SceneResponseFactory;
 import com.bdmage.mage_backend.service.SceneService;
 import com.bdmage.mage_backend.service.ThumbnailStorageService;
@@ -37,6 +39,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -46,6 +49,7 @@ class SceneControllerTests {
 	private final ObjectMapper objectMapper = new ObjectMapper();
 
 	private SceneService sceneService;
+	private SceneEngagementService sceneEngagementService;
 	private UserRepository userRepository;
 	private MockMvc mockMvc;
 	private LocalValidatorFactoryBean validator;
@@ -53,12 +57,15 @@ class SceneControllerTests {
 	@BeforeEach
 	void setUp() {
 		this.sceneService = mock(SceneService.class);
+		this.sceneEngagementService = mock(SceneEngagementService.class);
 		this.userRepository = mock(UserRepository.class);
 		this.validator = new LocalValidatorFactoryBean();
 		this.validator.afterPropertiesSet();
-		SceneResponseFactory sceneResponseFactory = new SceneResponseFactory(this.userRepository);
+		SceneResponseFactory sceneResponseFactory = new SceneResponseFactory(
+				this.userRepository,
+				this.sceneEngagementService);
 		this.mockMvc = MockMvcBuilders
-				.standaloneSetup(new SceneController(this.sceneService, sceneResponseFactory))
+				.standaloneSetup(new SceneController(this.sceneService, sceneResponseFactory, this.sceneEngagementService))
 				.setControllerAdvice(new ApiExceptionHandler())
 				.setValidator(this.validator)
 				.build();
@@ -233,6 +240,10 @@ class SceneControllerTests {
 		when(this.sceneService.getAllScenes()).thenReturn(List.of(firstScene, secondScene));
 		when(this.userRepository.findAllById(java.util.Set.of(77L, 78L)))
 				.thenReturn(List.of(user(77L, "Aurora Artist"), user(78L, "Signal Artist")));
+		when(this.sceneEngagementService.getSceneEngagement(15L, null))
+				.thenReturn(new SceneEngagementResponse(24L, 9L, 3L, 4L, null, false));
+		when(this.sceneEngagementService.getSceneEngagement(16L, null))
+				.thenReturn(new SceneEngagementResponse(12L, 2L, 1L, 1L, null, false));
 
 		this.mockMvc.perform(get("/api/scenes"))
 				.andExpect(status().isOk())
@@ -241,9 +252,14 @@ class SceneControllerTests {
 				.andExpect(jsonPath("$[0].creatorDisplayName").value("Aurora Artist"))
 				.andExpect(jsonPath("$[0].name").value("Aurora Drift"))
 				.andExpect(jsonPath("$[0].description").value("Soft teal bloom with low-end drift."))
+				.andExpect(jsonPath("$[0].engagement.views").value(24L))
+				.andExpect(jsonPath("$[0].engagement.upvotes").value(9L))
+				.andExpect(jsonPath("$[0].engagement.downvotes").value(3L))
+				.andExpect(jsonPath("$[0].engagement.saves").value(4L))
 				.andExpect(jsonPath("$[1].sceneId").value(16L))
 				.andExpect(jsonPath("$[1].creatorDisplayName").value("Signal Artist"))
-				.andExpect(jsonPath("$[1].name").value("Signal Bloom"));
+				.andExpect(jsonPath("$[1].name").value("Signal Bloom"))
+				.andExpect(jsonPath("$[1].engagement.views").value(12L));
 	}
 
 	@Test
@@ -261,6 +277,8 @@ class SceneControllerTests {
 		when(this.sceneService.getScenesByTag("ambient")).thenReturn(List.of(scene));
 		when(this.userRepository.findAllById(java.util.Set.of(77L)))
 				.thenReturn(List.of(user(77L, "Aurora Artist")));
+		when(this.sceneEngagementService.getSceneEngagement(15L, null))
+				.thenReturn(new SceneEngagementResponse(31L, 4L, 0L, 5L, null, false));
 
 		this.mockMvc.perform(get("/api/scenes").param("tag", "ambient"))
 				.andExpect(status().isOk())
@@ -268,7 +286,8 @@ class SceneControllerTests {
 				.andExpect(jsonPath("$[0].sceneId").value(15L))
 				.andExpect(jsonPath("$[0].creatorDisplayName").value("Aurora Artist"))
 				.andExpect(jsonPath("$[0].name").value("Aurora Drift"))
-				.andExpect(jsonPath("$[0].description").value("Filtered ambient drift."));
+				.andExpect(jsonPath("$[0].description").value("Filtered ambient drift."))
+				.andExpect(jsonPath("$[0].engagement.views").value(31L));
 	}
 
 	@Test
@@ -352,6 +371,8 @@ class SceneControllerTests {
 
 		when(this.sceneService.getScene(15L)).thenReturn(scene);
 		when(this.sceneService.getTagNamesForScene(15L)).thenReturn(List.of("ambient", "showcase"));
+		when(this.sceneEngagementService.getSceneEngagement(15L, null))
+				.thenReturn(new SceneEngagementResponse(0L, 0L, 0L, 0L, null, false));
 		when(this.userRepository.findById(77L)).thenReturn(Optional.of(user(77L, "Scene Creator")));
 
 		this.mockMvc.perform(get("/api/scenes/15"))
@@ -367,7 +388,130 @@ class SceneControllerTests {
 				.andExpect(jsonPath("$.thumbnailRef").value("https://cdn.example.com/scenes/15/thumbnails/thumb.png"))
 				.andExpect(jsonPath("$.createdAt").value("2026-03-26T15:30:00Z"))
 				.andExpect(jsonPath("$.tags[0]").value("ambient"))
-				.andExpect(jsonPath("$.tags[1]").value("showcase"));
+				.andExpect(jsonPath("$.tags[1]").value("showcase"))
+				.andExpect(jsonPath("$.engagement.views").value(0L))
+				.andExpect(jsonPath("$.engagement.upvotes").value(0L))
+				.andExpect(jsonPath("$.engagement.downvotes").value(0L))
+				.andExpect(jsonPath("$.engagement.saves").value(0L))
+				.andExpect(jsonPath("$.engagement.currentUserVote").doesNotExist())
+				.andExpect(jsonPath("$.engagement.currentUserSaved").value(false));
+	}
+
+	@Test
+	void getSceneReturnsCurrentUserEngagementStateWhenAuthenticated() throws Exception {
+		Scene scene = new Scene(
+				77L,
+				"Aurora Drift",
+				"A detail-page description.",
+				this.objectMapper.readTree("""
+						{"visualizer":{"shader":"nebula"}}
+						"""));
+		ReflectionTestUtils.setField(scene, "id", 15L);
+		ReflectionTestUtils.setField(scene, "createdAt", Instant.parse("2026-03-26T15:30:00Z"));
+
+		when(this.sceneService.getScene(15L)).thenReturn(scene);
+		when(this.sceneService.getTagNamesForScene(15L)).thenReturn(List.of());
+		when(this.sceneEngagementService.getSceneEngagement(15L, 77L))
+				.thenReturn(new SceneEngagementResponse(12L, 3L, 1L, 2L, "down", true));
+		when(this.userRepository.findById(77L)).thenReturn(Optional.of(user(77L, "Scene Creator")));
+
+		this.mockMvc.perform(get("/api/scenes/15")
+				.requestAttr(AuthenticatedUserRequest.USER_ID_ATTRIBUTE, 77L))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.sceneId").value(15L))
+				.andExpect(jsonPath("$.engagement.views").value(12L))
+				.andExpect(jsonPath("$.engagement.upvotes").value(3L))
+				.andExpect(jsonPath("$.engagement.downvotes").value(1L))
+				.andExpect(jsonPath("$.engagement.saves").value(2L))
+				.andExpect(jsonPath("$.engagement.currentUserVote").value("down"))
+				.andExpect(jsonPath("$.engagement.currentUserSaved").value(true));
+	}
+
+	@Test
+	void recordSceneViewReturnsUpdatedEngagementForPublicRequest() throws Exception {
+		when(this.sceneEngagementService.recordSceneView(15L, null))
+				.thenReturn(new SceneEngagementResponse(13L, 3L, 1L, 2L, null, false));
+
+		this.mockMvc.perform(post("/api/scenes/15/views"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.views").value(13L))
+				.andExpect(jsonPath("$.upvotes").value(3L))
+				.andExpect(jsonPath("$.downvotes").value(1L))
+				.andExpect(jsonPath("$.saves").value(2L))
+				.andExpect(jsonPath("$.currentUserVote").doesNotExist())
+				.andExpect(jsonPath("$.currentUserSaved").value(false));
+	}
+
+	@Test
+	void setSceneVoteReturnsUpdatedEngagementForAuthenticatedUser() throws Exception {
+		when(this.sceneEngagementService.setSceneVote(15L, 77L, "up"))
+				.thenReturn(new SceneEngagementResponse(12L, 4L, 1L, 2L, "up", true));
+
+		this.mockMvc.perform(put("/api/scenes/15/vote")
+				.requestAttr(AuthenticatedUserRequest.USER_ID_ATTRIBUTE, 77L)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+						{"vote":"up"}
+						"""))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.views").value(12L))
+				.andExpect(jsonPath("$.upvotes").value(4L))
+				.andExpect(jsonPath("$.downvotes").value(1L))
+				.andExpect(jsonPath("$.saves").value(2L))
+				.andExpect(jsonPath("$.currentUserVote").value("up"))
+				.andExpect(jsonPath("$.currentUserSaved").value(true));
+	}
+
+	@Test
+	void setSceneVoteRejectsInvalidVotePayload() throws Exception {
+		this.mockMvc.perform(put("/api/scenes/15/vote")
+				.requestAttr(AuthenticatedUserRequest.USER_ID_ATTRIBUTE, 77L)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+						{"vote":"sideways"}
+						"""))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+				.andExpect(jsonPath("$.details.vote").value("vote must be up or down"));
+	}
+
+	@Test
+	void clearSceneVoteReturnsUpdatedEngagementForAuthenticatedUser() throws Exception {
+		when(this.sceneEngagementService.clearSceneVote(15L, 77L))
+				.thenReturn(new SceneEngagementResponse(12L, 3L, 1L, 2L, null, true));
+
+		this.mockMvc.perform(delete("/api/scenes/15/vote")
+				.requestAttr(AuthenticatedUserRequest.USER_ID_ATTRIBUTE, 77L))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.upvotes").value(3L))
+				.andExpect(jsonPath("$.currentUserVote").doesNotExist())
+				.andExpect(jsonPath("$.currentUserSaved").value(true));
+	}
+
+	@Test
+	void saveSceneReturnsUpdatedEngagementForAuthenticatedUser() throws Exception {
+		when(this.sceneEngagementService.saveScene(15L, 77L))
+				.thenReturn(new SceneEngagementResponse(12L, 3L, 1L, 3L, "down", true));
+
+		this.mockMvc.perform(post("/api/scenes/15/save")
+				.requestAttr(AuthenticatedUserRequest.USER_ID_ATTRIBUTE, 77L))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.saves").value(3L))
+				.andExpect(jsonPath("$.currentUserVote").value("down"))
+				.andExpect(jsonPath("$.currentUserSaved").value(true));
+	}
+
+	@Test
+	void unsaveSceneReturnsUpdatedEngagementForAuthenticatedUser() throws Exception {
+		when(this.sceneEngagementService.unsaveScene(15L, 77L))
+				.thenReturn(new SceneEngagementResponse(12L, 3L, 1L, 2L, "down", false));
+
+		this.mockMvc.perform(delete("/api/scenes/15/save")
+				.requestAttr(AuthenticatedUserRequest.USER_ID_ATTRIBUTE, 77L))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.saves").value(2L))
+				.andExpect(jsonPath("$.currentUserVote").value("down"))
+				.andExpect(jsonPath("$.currentUserSaved").value(false));
 	}
 
 	@Test

--- a/src/test/java/com/bdmage/mage_backend/controller/UserControllerTests.java
+++ b/src/test/java/com/bdmage/mage_backend/controller/UserControllerTests.java
@@ -8,6 +8,8 @@ import com.bdmage.mage_backend.exception.AuthenticationRequiredException;
 import com.bdmage.mage_backend.model.Scene;
 import com.bdmage.mage_backend.model.User;
 import com.bdmage.mage_backend.repository.UserRepository;
+import com.bdmage.mage_backend.dto.SceneEngagementResponse;
+import com.bdmage.mage_backend.service.SceneEngagementService;
 import com.bdmage.mage_backend.service.SceneService;
 import com.bdmage.mage_backend.service.SceneResponseFactory;
 import com.bdmage.mage_backend.service.UserProfileService;
@@ -31,6 +33,7 @@ class UserControllerTests {
 	private final ObjectMapper objectMapper = new ObjectMapper();
 
 	private SceneService sceneService;
+	private SceneEngagementService sceneEngagementService;
 	private UserProfileService userProfileService;
 	private UserRepository userRepository;
 	private MockMvc mockMvc;
@@ -38,9 +41,12 @@ class UserControllerTests {
 	@BeforeEach
 	void setUp() {
 		this.sceneService = mock(SceneService.class);
+		this.sceneEngagementService = mock(SceneEngagementService.class);
 		this.userProfileService = mock(UserProfileService.class);
 		this.userRepository = mock(UserRepository.class);
-		SceneResponseFactory sceneResponseFactory = new SceneResponseFactory(this.userRepository);
+		SceneResponseFactory sceneResponseFactory = new SceneResponseFactory(
+				this.userRepository,
+				this.sceneEngagementService);
 		this.mockMvc = MockMvcBuilders
 				.standaloneSetup(new UserController(this.sceneService, this.userProfileService, sceneResponseFactory))
 				.setControllerAdvice(new ApiExceptionHandler())
@@ -131,6 +137,10 @@ class UserControllerTests {
 				.thenReturn(List.of(firstScene, secondScene));
 		when(this.userRepository.findAllById(java.util.Set.of(77L)))
 				.thenReturn(List.of(user(77L, "Scene Owner")));
+		when(this.sceneEngagementService.getSceneEngagement(15L, 51L))
+				.thenReturn(new SceneEngagementResponse(18L, 7L, 1L, 3L, null, false));
+		when(this.sceneEngagementService.getSceneEngagement(16L, 51L))
+				.thenReturn(new SceneEngagementResponse(9L, 2L, 0L, 1L, null, false));
 
 		this.mockMvc.perform(get("/api/users/77/scenes")
 				.requestAttr(AuthenticatedUserRequest.USER_ID_ATTRIBUTE, 51L))
@@ -142,9 +152,13 @@ class UserControllerTests {
 				.andExpect(jsonPath("$[0].description").value("Soft teal bloom with low-end drift."))
 				.andExpect(jsonPath("$[0].sceneData.visualizer.shader").value("nebula"))
 				.andExpect(jsonPath("$[0].createdAt").value("2026-03-26T15:30:00Z"))
+				.andExpect(jsonPath("$[0].engagement.views").value(18L))
+				.andExpect(jsonPath("$[0].engagement.upvotes").value(7L))
+				.andExpect(jsonPath("$[0].engagement.downvotes").value(1L))
 				.andExpect(jsonPath("$[1].sceneId").value(16L))
 				.andExpect(jsonPath("$[1].creatorDisplayName").value("Scene Owner"))
-				.andExpect(jsonPath("$[1].name").value("Signal Bloom"));
+				.andExpect(jsonPath("$[1].name").value("Signal Bloom"))
+				.andExpect(jsonPath("$[1].engagement.views").value(9L));
 	}
 
 	@Test


### PR DESCRIPTION
## Summary
- Add scene engagement persistence for views, votes, and saves.
- Expose engagement summaries on scene detail and scene list responses.
- Add public `POST /api/scenes/:id/views` plus authenticated vote/save endpoints.
- Keep optional auth for public scene reads and view recording.

## Tests
- `.\mvnw.cmd '-Dtest=!*IntegrationTests,!*IntegrationTest,!MageBackendApplicationTests' test`
- `.\mvnw.cmd '-Dtest=SceneControllerIntegrationTests,UserControllerIntegrationTests' test`
