### PR TITLE
109 add comment replies and comment voting

### DIFF
--- a/src/main/java/com/bdmage/mage_backend/config/AuthenticationConfiguration.java
+++ b/src/main/java/com/bdmage/mage_backend/config/AuthenticationConfiguration.java
@@ -16,6 +16,6 @@ public class AuthenticationConfiguration implements WebMvcConfigurer {
 	@Override
 	public void addInterceptors(InterceptorRegistry registry) {
 		registry.addInterceptor(this.authenticationInterceptor)
-				.addPathPatterns("/api/users/**", "/api/scenes/**");
+				.addPathPatterns("/api/users/**", "/api/scenes/**", "/api/presets/**");
 	}
 }

--- a/src/main/java/com/bdmage/mage_backend/config/AuthenticationInterceptor.java
+++ b/src/main/java/com/bdmage/mage_backend/config/AuthenticationInterceptor.java
@@ -20,7 +20,9 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
 	private static final String BEARER_PREFIX = "Bearer ";
 	private static final List<String> PUBLIC_SCENE_READ_PATTERNS = List.of(
 			"/api/scenes",
-			"/api/scenes/{id}");
+			"/api/scenes/{id}",
+			"/api/scenes/{id}/comments",
+			"/api/presets/{id}/comments");
 	private static final String PUBLIC_SCENE_VIEW_PATTERN = "/api/scenes/{id}/views";
 	private static final AntPathMatcher PATH_MATCHER = new AntPathMatcher();
 

--- a/src/main/java/com/bdmage/mage_backend/controller/SceneCommentController.java
+++ b/src/main/java/com/bdmage/mage_backend/controller/SceneCommentController.java
@@ -1,0 +1,73 @@
+package com.bdmage.mage_backend.controller;
+
+import java.util.List;
+
+import com.bdmage.mage_backend.config.AuthenticatedUserRequest;
+import com.bdmage.mage_backend.dto.CreateSceneCommentRequest;
+import com.bdmage.mage_backend.dto.SceneCommentResponse;
+import com.bdmage.mage_backend.dto.UpdateCommentVoteRequest;
+import com.bdmage.mage_backend.service.SceneCommentService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestAttribute;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping({"/api/scenes/{sceneId}/comments", "/api/presets/{sceneId}/comments"})
+public class SceneCommentController {
+
+	private final SceneCommentService sceneCommentService;
+
+	public SceneCommentController(SceneCommentService sceneCommentService) {
+		this.sceneCommentService = sceneCommentService;
+	}
+
+	@GetMapping
+	ResponseEntity<List<SceneCommentResponse>> getSceneComments(
+			@RequestAttribute(name = AuthenticatedUserRequest.USER_ID_ATTRIBUTE, required = false) Long authenticatedUserId,
+			@PathVariable Long sceneId) {
+		return ResponseEntity.ok(this.sceneCommentService.getSceneComments(sceneId, authenticatedUserId));
+	}
+
+	@PostMapping
+	ResponseEntity<SceneCommentResponse> createSceneComment(
+			@RequestAttribute(name = AuthenticatedUserRequest.USER_ID_ATTRIBUTE, required = false) Long authenticatedUserId,
+			@PathVariable Long sceneId,
+			@Valid @RequestBody CreateSceneCommentRequest request) {
+		return ResponseEntity.status(HttpStatus.CREATED)
+				.body(this.sceneCommentService.createSceneComment(
+						sceneId,
+						authenticatedUserId,
+						request.text(),
+						request.parentCommentId()));
+	}
+
+	@PutMapping("/{commentId}/vote")
+	ResponseEntity<SceneCommentResponse> setCommentVote(
+			@RequestAttribute(name = AuthenticatedUserRequest.USER_ID_ATTRIBUTE, required = false) Long authenticatedUserId,
+			@PathVariable Long sceneId,
+			@PathVariable Long commentId,
+			@Valid @RequestBody UpdateCommentVoteRequest request) {
+		return ResponseEntity.ok(this.sceneCommentService.setCommentVote(
+				sceneId,
+				commentId,
+				authenticatedUserId,
+				request.vote()));
+	}
+
+	@DeleteMapping("/{commentId}/vote")
+	ResponseEntity<SceneCommentResponse> clearCommentVote(
+			@RequestAttribute(name = AuthenticatedUserRequest.USER_ID_ATTRIBUTE, required = false) Long authenticatedUserId,
+			@PathVariable Long sceneId,
+			@PathVariable Long commentId) {
+		return ResponseEntity.ok(this.sceneCommentService.clearCommentVote(sceneId, commentId, authenticatedUserId));
+	}
+}

--- a/src/main/java/com/bdmage/mage_backend/dto/CreateSceneCommentRequest.java
+++ b/src/main/java/com/bdmage/mage_backend/dto/CreateSceneCommentRequest.java
@@ -1,0 +1,13 @@
+package com.bdmage.mage_backend.dto;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CreateSceneCommentRequest(
+		@JsonAlias("body")
+		@NotBlank(message = "text must not be blank")
+		@Size(max = 2000, message = "text must be at most 2000 characters")
+		String text,
+		Long parentCommentId) {
+}

--- a/src/main/java/com/bdmage/mage_backend/dto/SceneCommentResponse.java
+++ b/src/main/java/com/bdmage/mage_backend/dto/SceneCommentResponse.java
@@ -1,0 +1,76 @@
+package com.bdmage.mage_backend.dto;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.bdmage.mage_backend.repository.SceneCommentSummaryProjection;
+
+public record SceneCommentResponse(
+		Long commentId,
+		Long sceneId,
+		Long parentCommentId,
+		Long authorUserId,
+		String authorDisplayName,
+		String text,
+		Instant createdAt,
+		long replyCount,
+		long upvotes,
+		long downvotes,
+		String currentUserVote,
+		List<SceneCommentResponse> replies) {
+
+	public static List<SceneCommentResponse> listFrom(List<SceneCommentSummaryProjection> summaries) {
+		Map<Long, List<SceneCommentSummaryProjection>> repliesByParentId = summaries.stream()
+				.filter(summary -> summary.getParentCommentId() != null)
+				.collect(Collectors.groupingBy(SceneCommentSummaryProjection::getParentCommentId));
+
+		return summaries.stream()
+				.filter(summary -> summary.getParentCommentId() == null)
+				.map(summary -> from(
+						summary,
+						repliesByParentId.getOrDefault(summary.getCommentId(), List.of()).stream()
+								.map(reply -> from(reply, List.of()))
+								.toList()))
+				.toList();
+	}
+
+	public static SceneCommentResponse from(SceneCommentSummaryProjection summary) {
+		return from(summary, List.of());
+	}
+
+	public static SceneCommentResponse from(
+			SceneCommentSummaryProjection summary,
+			List<SceneCommentResponse> replies) {
+		return new SceneCommentResponse(
+				summary.getCommentId(),
+				summary.getSceneId(),
+				summary.getParentCommentId(),
+				summary.getAuthorUserId(),
+				summary.getAuthorDisplayName(),
+				summary.getText(),
+				summary.getCreatedAt(),
+				longValue(summary.getReplyCount()),
+				longValue(summary.getUpvotes()),
+				longValue(summary.getDownvotes()),
+				currentUserVote(summary.getCurrentUserVoteValue()),
+				List.copyOf(replies));
+	}
+
+	private static long longValue(Number value) {
+		return value == null ? 0L : value.longValue();
+	}
+
+	private static String currentUserVote(Number value) {
+		if (value == null) {
+			return null;
+		}
+
+		return switch (value.intValue()) {
+			case 1 -> "up";
+			case -1 -> "down";
+			default -> null;
+		};
+	}
+}

--- a/src/main/java/com/bdmage/mage_backend/dto/UpdateCommentVoteRequest.java
+++ b/src/main/java/com/bdmage/mage_backend/dto/UpdateCommentVoteRequest.java
@@ -1,0 +1,10 @@
+package com.bdmage.mage_backend.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record UpdateCommentVoteRequest(
+		@NotBlank(message = "vote must not be blank")
+		@Pattern(regexp = "up|down", message = "vote must be up or down")
+		String vote) {
+}

--- a/src/main/java/com/bdmage/mage_backend/exception/ApiExceptionHandler.java
+++ b/src/main/java/com/bdmage/mage_backend/exception/ApiExceptionHandler.java
@@ -220,6 +220,30 @@ public class ApiExceptionHandler {
 			request.getRequestURI());
 	}
 
+	@ExceptionHandler(SceneCommentNotFoundException.class)
+	ResponseEntity<ApiErrorResponse> handleSceneCommentNotFound(
+			SceneCommentNotFoundException ex,
+			HttpServletRequest request) {
+		return buildResponse(
+			HttpStatus.NOT_FOUND,
+			"COMMENT_NOT_FOUND",
+			ex.getMessage(),
+			Map.of(),
+			request.getRequestURI());
+	}
+
+	@ExceptionHandler(InvalidSceneCommentParentException.class)
+	ResponseEntity<ApiErrorResponse> handleInvalidSceneCommentParent(
+			InvalidSceneCommentParentException ex,
+			HttpServletRequest request) {
+		return buildResponse(
+			HttpStatus.BAD_REQUEST,
+			"INVALID_COMMENT_PARENT",
+			ex.getMessage(),
+			Map.of(),
+			request.getRequestURI());
+	}
+
 	@ExceptionHandler(SceneForbiddenException.class)
 	ResponseEntity<ApiErrorResponse> handleForbiddenException(
 			SceneForbiddenException ex,

--- a/src/main/java/com/bdmage/mage_backend/exception/InvalidSceneCommentParentException.java
+++ b/src/main/java/com/bdmage/mage_backend/exception/InvalidSceneCommentParentException.java
@@ -1,0 +1,8 @@
+package com.bdmage.mage_backend.exception;
+
+public class InvalidSceneCommentParentException extends RuntimeException {
+
+	public InvalidSceneCommentParentException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/bdmage/mage_backend/exception/SceneCommentNotFoundException.java
+++ b/src/main/java/com/bdmage/mage_backend/exception/SceneCommentNotFoundException.java
@@ -1,0 +1,8 @@
+package com.bdmage.mage_backend.exception;
+
+public class SceneCommentNotFoundException extends RuntimeException {
+
+	public SceneCommentNotFoundException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/bdmage/mage_backend/model/SceneComment.java
+++ b/src/main/java/com/bdmage/mage_backend/model/SceneComment.java
@@ -1,0 +1,69 @@
+package com.bdmage.mage_backend.model;
+
+import java.time.Instant;
+import java.util.Objects;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+@Entity
+@Table(name = "scene_comments")
+public class SceneComment {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "scene_id", nullable = false)
+	private Long sceneId;
+
+	@Column(name = "user_id", nullable = false)
+	private Long userId;
+
+	@Column(name = "parent_comment_id")
+	private Long parentCommentId;
+
+	@Column(name = "body", nullable = false, length = 2000)
+	private String body;
+
+	@Column(name = "created_at", nullable = false, insertable = false, updatable = false)
+	private Instant createdAt;
+
+	protected SceneComment() {
+	}
+
+	public SceneComment(Long sceneId, Long userId, Long parentCommentId, String body) {
+		this.sceneId = Objects.requireNonNull(sceneId, "sceneId must not be null");
+		this.userId = Objects.requireNonNull(userId, "userId must not be null");
+		this.parentCommentId = parentCommentId;
+		this.body = Objects.requireNonNull(body, "body must not be null");
+	}
+
+	public Long getId() {
+		return this.id;
+	}
+
+	public Long getSceneId() {
+		return this.sceneId;
+	}
+
+	public Long getUserId() {
+		return this.userId;
+	}
+
+	public Long getParentCommentId() {
+		return this.parentCommentId;
+	}
+
+	public String getBody() {
+		return this.body;
+	}
+
+	public Instant getCreatedAt() {
+		return this.createdAt;
+	}
+}

--- a/src/main/java/com/bdmage/mage_backend/repository/SceneCommentRepository.java
+++ b/src/main/java/com/bdmage/mage_backend/repository/SceneCommentRepository.java
@@ -1,0 +1,80 @@
+package com.bdmage.mage_backend.repository;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.bdmage.mage_backend.model.SceneComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface SceneCommentRepository extends JpaRepository<SceneComment, Long> {
+
+	@Query(value = """
+			SELECT
+			  sc.id AS "commentId",
+			  sc.scene_id AS "sceneId",
+			  sc.parent_comment_id AS "parentCommentId",
+			  sc.user_id AS "authorUserId",
+			  u.display_name AS "authorDisplayName",
+			  sc.body AS "text",
+			  sc.created_at AS "createdAt",
+			  (SELECT COUNT(*) FROM scene_comments replies WHERE replies.parent_comment_id = sc.id) AS "replyCount",
+			  (SELECT COUNT(*) FROM scene_comment_votes scv WHERE scv.comment_id = sc.id AND scv.vote_value = 1) AS upvotes,
+			  (SELECT COUNT(*) FROM scene_comment_votes scv WHERE scv.comment_id = sc.id AND scv.vote_value = -1) AS downvotes,
+			  (SELECT scv.vote_value FROM scene_comment_votes scv WHERE scv.comment_id = sc.id AND scv.user_id = :currentUserId) AS "currentUserVoteValue"
+			FROM scene_comments sc
+			JOIN users u ON u.id = sc.user_id
+			WHERE sc.scene_id = :sceneId
+			ORDER BY sc.created_at ASC, sc.id ASC
+			""", nativeQuery = true)
+	List<SceneCommentSummaryProjection> summarizeSceneComments(
+			@Param("sceneId") Long sceneId,
+			@Param("currentUserId") Long currentUserId);
+
+	@Query(value = """
+			SELECT
+			  sc.id AS "commentId",
+			  sc.scene_id AS "sceneId",
+			  sc.parent_comment_id AS "parentCommentId",
+			  sc.user_id AS "authorUserId",
+			  u.display_name AS "authorDisplayName",
+			  sc.body AS "text",
+			  sc.created_at AS "createdAt",
+			  (SELECT COUNT(*) FROM scene_comments replies WHERE replies.parent_comment_id = sc.id) AS "replyCount",
+			  (SELECT COUNT(*) FROM scene_comment_votes scv WHERE scv.comment_id = sc.id AND scv.vote_value = 1) AS upvotes,
+			  (SELECT COUNT(*) FROM scene_comment_votes scv WHERE scv.comment_id = sc.id AND scv.vote_value = -1) AS downvotes,
+			  (SELECT scv.vote_value FROM scene_comment_votes scv WHERE scv.comment_id = sc.id AND scv.user_id = :currentUserId) AS "currentUserVoteValue"
+			FROM scene_comments sc
+			JOIN users u ON u.id = sc.user_id
+			WHERE sc.scene_id = :sceneId
+			  AND sc.id = :commentId
+			""", nativeQuery = true)
+	Optional<SceneCommentSummaryProjection> summarizeSceneComment(
+			@Param("sceneId") Long sceneId,
+			@Param("commentId") Long commentId,
+			@Param("currentUserId") Long currentUserId);
+
+	@Modifying
+	@Query(value = """
+			INSERT INTO scene_comment_votes (comment_id, user_id, vote_value)
+			VALUES (:commentId, :userId, :voteValue)
+			ON CONFLICT (comment_id, user_id)
+			DO UPDATE SET
+			  vote_value = EXCLUDED.vote_value,
+			  updated_at = CURRENT_TIMESTAMP
+			""", nativeQuery = true)
+	void upsertCommentVote(
+			@Param("commentId") Long commentId,
+			@Param("userId") Long userId,
+			@Param("voteValue") int voteValue);
+
+	@Modifying
+	@Query(value = """
+			DELETE FROM scene_comment_votes
+			WHERE comment_id = :commentId
+			  AND user_id = :userId
+			""", nativeQuery = true)
+	void deleteCommentVote(@Param("commentId") Long commentId, @Param("userId") Long userId);
+}

--- a/src/main/java/com/bdmage/mage_backend/repository/SceneCommentSummaryProjection.java
+++ b/src/main/java/com/bdmage/mage_backend/repository/SceneCommentSummaryProjection.java
@@ -1,0 +1,28 @@
+package com.bdmage.mage_backend.repository;
+
+import java.time.Instant;
+
+public interface SceneCommentSummaryProjection {
+
+	Long getCommentId();
+
+	Long getSceneId();
+
+	Long getParentCommentId();
+
+	Long getAuthorUserId();
+
+	String getAuthorDisplayName();
+
+	String getText();
+
+	Instant getCreatedAt();
+
+	Number getReplyCount();
+
+	Number getUpvotes();
+
+	Number getDownvotes();
+
+	Number getCurrentUserVoteValue();
+}

--- a/src/main/java/com/bdmage/mage_backend/service/SceneCommentService.java
+++ b/src/main/java/com/bdmage/mage_backend/service/SceneCommentService.java
@@ -1,0 +1,138 @@
+package com.bdmage.mage_backend.service;
+
+import java.util.List;
+
+import com.bdmage.mage_backend.dto.SceneCommentResponse;
+import com.bdmage.mage_backend.exception.AuthenticationRequiredException;
+import com.bdmage.mage_backend.exception.InvalidSceneCommentParentException;
+import com.bdmage.mage_backend.exception.SceneCommentNotFoundException;
+import com.bdmage.mage_backend.exception.SceneNotFoundException;
+import com.bdmage.mage_backend.model.SceneComment;
+import com.bdmage.mage_backend.repository.SceneCommentRepository;
+import com.bdmage.mage_backend.repository.SceneCommentSummaryProjection;
+import com.bdmage.mage_backend.repository.SceneRepository;
+import com.bdmage.mage_backend.repository.UserRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class SceneCommentService {
+
+	private static final String AUTHENTICATION_REQUIRED_MESSAGE = "Authentication is required.";
+	private static final String COMMENT_NOT_FOUND_MESSAGE = "Comment not found.";
+	private static final String INVALID_PARENT_MESSAGE = "Parent comment must be a top-level comment on this scene.";
+	private static final String SCENE_NOT_FOUND_MESSAGE = "Scene not found.";
+
+	private final SceneCommentRepository sceneCommentRepository;
+	private final SceneRepository sceneRepository;
+	private final UserRepository userRepository;
+
+	public SceneCommentService(
+			SceneCommentRepository sceneCommentRepository,
+			SceneRepository sceneRepository,
+			UserRepository userRepository) {
+		this.sceneCommentRepository = sceneCommentRepository;
+		this.sceneRepository = sceneRepository;
+		this.userRepository = userRepository;
+	}
+
+	@Transactional(readOnly = true)
+	public List<SceneCommentResponse> getSceneComments(Long sceneId, Long currentUserId) {
+		requireSceneExists(sceneId);
+		return SceneCommentResponse.listFrom(
+				this.sceneCommentRepository.summarizeSceneComments(sceneId, currentUserId));
+	}
+
+	@Transactional
+	public SceneCommentResponse createSceneComment(
+			Long sceneId,
+			Long currentUserId,
+			String text,
+			Long parentCommentId) {
+		requireAuthenticatedUser(currentUserId);
+		requireSceneExists(sceneId);
+		validateParentComment(sceneId, parentCommentId);
+
+		SceneComment comment = this.sceneCommentRepository.save(new SceneComment(
+				sceneId,
+				currentUserId,
+				parentCommentId,
+				text.trim()));
+
+		return summarizeSceneComment(sceneId, comment.getId(), currentUserId);
+	}
+
+	@Transactional
+	public SceneCommentResponse setCommentVote(
+			Long sceneId,
+			Long commentId,
+			Long currentUserId,
+			String vote) {
+		requireAuthenticatedUser(currentUserId);
+		requireSceneExists(sceneId);
+		requireCommentInScene(sceneId, commentId);
+
+		this.sceneCommentRepository.upsertCommentVote(commentId, currentUserId, voteValue(vote));
+		return summarizeSceneComment(sceneId, commentId, currentUserId);
+	}
+
+	@Transactional
+	public SceneCommentResponse clearCommentVote(Long sceneId, Long commentId, Long currentUserId) {
+		requireAuthenticatedUser(currentUserId);
+		requireSceneExists(sceneId);
+		requireCommentInScene(sceneId, commentId);
+
+		this.sceneCommentRepository.deleteCommentVote(commentId, currentUserId);
+		return summarizeSceneComment(sceneId, commentId, currentUserId);
+	}
+
+	private void requireAuthenticatedUser(Long currentUserId) {
+		if (currentUserId == null || !this.userRepository.existsById(currentUserId)) {
+			throw new AuthenticationRequiredException(AUTHENTICATION_REQUIRED_MESSAGE);
+		}
+	}
+
+	private void requireSceneExists(Long sceneId) {
+		if (!this.sceneRepository.existsById(sceneId)) {
+			throw new SceneNotFoundException(SCENE_NOT_FOUND_MESSAGE);
+		}
+	}
+
+	private void requireCommentInScene(Long sceneId, Long commentId) {
+		SceneComment comment = this.sceneCommentRepository.findById(commentId)
+				.orElseThrow(() -> new SceneCommentNotFoundException(COMMENT_NOT_FOUND_MESSAGE));
+
+		if (!sceneId.equals(comment.getSceneId())) {
+			throw new SceneCommentNotFoundException(COMMENT_NOT_FOUND_MESSAGE);
+		}
+	}
+
+	private void validateParentComment(Long sceneId, Long parentCommentId) {
+		if (parentCommentId == null) {
+			return;
+		}
+
+		SceneComment parentComment = this.sceneCommentRepository.findById(parentCommentId)
+				.orElseThrow(() -> new InvalidSceneCommentParentException(INVALID_PARENT_MESSAGE));
+
+		if (!sceneId.equals(parentComment.getSceneId()) || parentComment.getParentCommentId() != null) {
+			throw new InvalidSceneCommentParentException(INVALID_PARENT_MESSAGE);
+		}
+	}
+
+	private SceneCommentResponse summarizeSceneComment(Long sceneId, Long commentId, Long currentUserId) {
+		SceneCommentSummaryProjection summary = this.sceneCommentRepository
+				.summarizeSceneComment(sceneId, commentId, currentUserId)
+				.orElseThrow(() -> new SceneCommentNotFoundException(COMMENT_NOT_FOUND_MESSAGE));
+
+		return SceneCommentResponse.from(summary);
+	}
+
+	private static int voteValue(String vote) {
+		return switch (vote) {
+			case "up" -> 1;
+			case "down" -> -1;
+			default -> throw new IllegalArgumentException("Unsupported comment vote: " + vote);
+		};
+	}
+}

--- a/src/main/resources/db/migration/V13__create_scene_comments_tables.sql
+++ b/src/main/resources/db/migration/V13__create_scene_comments_tables.sql
@@ -1,0 +1,27 @@
+CREATE TABLE scene_comments (
+  id BIGSERIAL PRIMARY KEY,
+  scene_id BIGINT NOT NULL REFERENCES scenes(id) ON DELETE CASCADE,
+  user_id BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  parent_comment_id BIGINT REFERENCES scene_comments(id) ON DELETE CASCADE,
+  body VARCHAR(2000) NOT NULL CHECK (char_length(trim(body)) > 0),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX scene_comments_scene_id_parent_comment_id_idx
+  ON scene_comments (scene_id, parent_comment_id, created_at, id);
+
+CREATE INDEX scene_comments_user_id_idx ON scene_comments (user_id);
+
+CREATE TABLE scene_comment_votes (
+  comment_id BIGINT NOT NULL REFERENCES scene_comments(id) ON DELETE CASCADE,
+  user_id BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  vote_value SMALLINT NOT NULL CHECK (vote_value IN (-1, 1)),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (comment_id, user_id)
+);
+
+CREATE INDEX scene_comment_votes_comment_id_vote_value_idx
+  ON scene_comment_votes (comment_id, vote_value);
+
+CREATE INDEX scene_comment_votes_user_id_idx ON scene_comment_votes (user_id);

--- a/src/test/java/com/bdmage/mage_backend/config/AuthenticationInterceptorTests.java
+++ b/src/test/java/com/bdmage/mage_backend/config/AuthenticationInterceptorTests.java
@@ -94,6 +94,32 @@ class AuthenticationInterceptorTests {
 	}
 
 	@Test
+	void preHandleAllowsPublicApiSceneCommentsRequestWithoutAuthenticationHeader() {
+		AuthenticationTokenService authenticationTokenService = mock(AuthenticationTokenService.class);
+		AuthenticationInterceptor interceptor = new AuthenticationInterceptor(authenticationTokenService);
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/scenes/15/comments");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		assertThat(interceptor.preHandle(request, response, new Object())).isTrue();
+		assertThat(request.getAttribute(AuthenticatedUserRequest.USER_ATTRIBUTE)).isNull();
+		assertThat(request.getAttribute(AuthenticatedUserRequest.USER_ID_ATTRIBUTE)).isNull();
+		verifyNoInteractions(authenticationTokenService);
+	}
+
+	@Test
+	void preHandleAllowsPublicApiPresetCommentsRequestWithoutAuthenticationHeader() {
+		AuthenticationTokenService authenticationTokenService = mock(AuthenticationTokenService.class);
+		AuthenticationInterceptor interceptor = new AuthenticationInterceptor(authenticationTokenService);
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/presets/15/comments");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		assertThat(interceptor.preHandle(request, response, new Object())).isTrue();
+		assertThat(request.getAttribute(AuthenticatedUserRequest.USER_ATTRIBUTE)).isNull();
+		assertThat(request.getAttribute(AuthenticatedUserRequest.USER_ID_ATTRIBUTE)).isNull();
+		verifyNoInteractions(authenticationTokenService);
+	}
+
+	@Test
 	void preHandleAllowsPublicApiSceneViewRequestWithoutAuthenticationHeader() {
 		AuthenticationTokenService authenticationTokenService = mock(AuthenticationTokenService.class);
 		AuthenticationInterceptor interceptor = new AuthenticationInterceptor(authenticationTokenService);

--- a/src/test/java/com/bdmage/mage_backend/controller/SceneCommentControllerIntegrationTests.java
+++ b/src/test/java/com/bdmage/mage_backend/controller/SceneCommentControllerIntegrationTests.java
@@ -1,0 +1,267 @@
+package com.bdmage.mage_backend.controller;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.bdmage.mage_backend.model.Scene;
+import com.bdmage.mage_backend.model.User;
+import com.bdmage.mage_backend.repository.SceneRepository;
+import com.bdmage.mage_backend.repository.UserRepository;
+import com.bdmage.mage_backend.service.PasswordHashingService;
+import com.bdmage.mage_backend.support.PostgresIntegrationTestSupport;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ActiveProfiles("test")
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+@SpringBootTest
+@AutoConfigureMockMvc
+@Testcontainers
+class SceneCommentControllerIntegrationTests extends PostgresIntegrationTestSupport {
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Autowired
+	private SceneRepository sceneRepository;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private PasswordHashingService passwordHashingService;
+
+	@Test
+	void createReplyAndListCommentsReturnsNestedStructure() throws Exception {
+		String uniqueSuffix = String.valueOf(System.nanoTime());
+		User author = saveUser("comment-author-" + uniqueSuffix, "Comment Author");
+		Scene scene = saveScene(author.getId(), "Commented Scene");
+		String accessToken = accessToken(author.getEmail(), "password-" + author.getEmail());
+
+		MvcResult parentResult = this.mockMvc.perform(post("/api/scenes/" + scene.getId() + "/comments")
+				.header("Authorization", "Bearer " + accessToken)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+						{"text":"First pass is hypnotic."}
+						"""))
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.sceneId").value(scene.getId()))
+				.andExpect(jsonPath("$.authorUserId").value(author.getId()))
+				.andExpect(jsonPath("$.authorDisplayName").value("Comment Author"))
+				.andExpect(jsonPath("$.text").value("First pass is hypnotic."))
+				.andExpect(jsonPath("$.replyCount").value(0L))
+				.andExpect(jsonPath("$.upvotes").value(0L))
+				.andExpect(jsonPath("$.downvotes").value(0L))
+				.andExpect(jsonPath("$.currentUserVote").doesNotExist())
+				.andReturn();
+
+		Long parentCommentId = commentId(parentResult);
+		MvcResult replyResult = this.mockMvc.perform(post("/api/presets/" + scene.getId() + "/comments")
+				.header("Authorization", "Bearer " + accessToken)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+						{"text":"The second drop lands even better.","parentCommentId":%d}
+						""".formatted(parentCommentId)))
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.parentCommentId").value(parentCommentId))
+				.andExpect(jsonPath("$.text").value("The second drop lands even better."))
+				.andReturn();
+
+		Long replyCommentId = commentId(replyResult);
+
+		this.mockMvc.perform(get("/api/scenes/" + scene.getId() + "/comments"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.length()").value(1))
+				.andExpect(jsonPath("$[0].commentId").value(parentCommentId))
+				.andExpect(jsonPath("$[0].sceneId").value(scene.getId()))
+				.andExpect(jsonPath("$[0].parentCommentId").doesNotExist())
+				.andExpect(jsonPath("$[0].authorDisplayName").value("Comment Author"))
+				.andExpect(jsonPath("$[0].text").value("First pass is hypnotic."))
+				.andExpect(jsonPath("$[0].replyCount").value(1L))
+				.andExpect(jsonPath("$[0].upvotes").value(0L))
+				.andExpect(jsonPath("$[0].downvotes").value(0L))
+				.andExpect(jsonPath("$[0].currentUserVote").doesNotExist())
+				.andExpect(jsonPath("$[0].replies.length()").value(1))
+				.andExpect(jsonPath("$[0].replies[0].commentId").value(replyCommentId))
+				.andExpect(jsonPath("$[0].replies[0].parentCommentId").value(parentCommentId))
+				.andExpect(jsonPath("$[0].replies[0].text").value("The second drop lands even better."))
+				.andExpect(jsonPath("$[0].replies[0].replyCount").value(0L));
+	}
+
+	@Test
+	void commentVoteCanSwitchAndClearForAuthenticatedUser() throws Exception {
+		String uniqueSuffix = String.valueOf(System.nanoTime());
+		User author = saveUser("vote-author-" + uniqueSuffix, "Vote Author");
+		User voter = saveUser("vote-user-" + uniqueSuffix, "Vote User");
+		Scene scene = saveScene(author.getId(), "Voted Scene");
+		String authorToken = accessToken(author.getEmail(), "password-" + author.getEmail());
+		String voterToken = accessToken(voter.getEmail(), "password-" + voter.getEmail());
+		Long commentId = createComment(scene.getId(), authorToken, "Vote on this texture.");
+
+		this.mockMvc.perform(put("/api/scenes/" + scene.getId() + "/comments/" + commentId + "/vote")
+				.header("Authorization", "Bearer " + voterToken)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+						{"vote":"up"}
+						"""))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.upvotes").value(1L))
+				.andExpect(jsonPath("$.downvotes").value(0L))
+				.andExpect(jsonPath("$.currentUserVote").value("up"));
+
+		this.mockMvc.perform(put("/api/scenes/" + scene.getId() + "/comments/" + commentId + "/vote")
+				.header("Authorization", "Bearer " + voterToken)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+						{"vote":"down"}
+						"""))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.upvotes").value(0L))
+				.andExpect(jsonPath("$.downvotes").value(1L))
+				.andExpect(jsonPath("$.currentUserVote").value("down"));
+
+		this.mockMvc.perform(get("/api/scenes/" + scene.getId() + "/comments")
+				.header("Authorization", "Bearer " + voterToken))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$[0].upvotes").value(0L))
+				.andExpect(jsonPath("$[0].downvotes").value(1L))
+				.andExpect(jsonPath("$[0].currentUserVote").value("down"));
+
+		this.mockMvc.perform(delete("/api/scenes/" + scene.getId() + "/comments/" + commentId + "/vote")
+				.header("Authorization", "Bearer " + voterToken))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.upvotes").value(0L))
+				.andExpect(jsonPath("$.downvotes").value(0L))
+				.andExpect(jsonPath("$.currentUserVote").doesNotExist());
+	}
+
+	@Test
+	void createReplyRejectsInvalidParentReferences() throws Exception {
+		String uniqueSuffix = String.valueOf(System.nanoTime());
+		User author = saveUser("invalid-parent-author-" + uniqueSuffix, "Invalid Parent Author");
+		Scene firstScene = saveScene(author.getId(), "First Commented Scene");
+		Scene secondScene = saveScene(author.getId(), "Second Commented Scene");
+		String accessToken = accessToken(author.getEmail(), "password-" + author.getEmail());
+		Long parentCommentId = createComment(firstScene.getId(), accessToken, "Parent comment.");
+		Long replyCommentId = createReply(firstScene.getId(), accessToken, parentCommentId, "Existing reply.");
+
+		this.mockMvc.perform(post("/api/scenes/" + secondScene.getId() + "/comments")
+				.header("Authorization", "Bearer " + accessToken)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+						{"text":"Cross-scene reply.","parentCommentId":%d}
+						""".formatted(parentCommentId)))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code").value("INVALID_COMMENT_PARENT"))
+				.andExpect(jsonPath("$.message").value("Parent comment must be a top-level comment on this scene."));
+
+		this.mockMvc.perform(post("/api/scenes/" + firstScene.getId() + "/comments")
+				.header("Authorization", "Bearer " + accessToken)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+						{"text":"Nested reply.","parentCommentId":%d}
+						""".formatted(replyCommentId)))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code").value("INVALID_COMMENT_PARENT"))
+				.andExpect(jsonPath("$.message").value("Parent comment must be a top-level comment on this scene."));
+	}
+
+	@Test
+	void commentVoteRequiresAuthentication() throws Exception {
+		String uniqueSuffix = String.valueOf(System.nanoTime());
+		User author = saveUser("unauth-comment-author-" + uniqueSuffix, "Unauth Comment Author");
+		Scene scene = saveScene(author.getId(), "Unauthenticated Vote Scene");
+		String accessToken = accessToken(author.getEmail(), "password-" + author.getEmail());
+		Long commentId = createComment(scene.getId(), accessToken, "Anonymous votes should fail.");
+
+		this.mockMvc.perform(put("/api/scenes/" + scene.getId() + "/comments/" + commentId + "/vote")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+						{"vote":"up"}
+						"""))
+				.andExpect(status().isUnauthorized())
+				.andExpect(jsonPath("$.code").value("AUTHENTICATION_REQUIRED"))
+				.andExpect(jsonPath("$.message").value("Authentication is required."));
+	}
+
+	private Long createComment(Long sceneId, String accessToken, String text) throws Exception {
+		MvcResult result = this.mockMvc.perform(post("/api/scenes/" + sceneId + "/comments")
+				.header("Authorization", "Bearer " + accessToken)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"text\":\"" + text + "\"}"))
+				.andExpect(status().isCreated())
+				.andReturn();
+
+		return commentId(result);
+	}
+
+	private Long createReply(Long sceneId, String accessToken, Long parentCommentId, String text) throws Exception {
+		MvcResult result = this.mockMvc.perform(post("/api/scenes/" + sceneId + "/comments")
+				.header("Authorization", "Bearer " + accessToken)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+						{"text":"%s","parentCommentId":%d}
+						""".formatted(text, parentCommentId)))
+				.andExpect(status().isCreated())
+				.andReturn();
+
+		return commentId(result);
+	}
+
+	private User saveUser(String emailPrefix, String displayName) {
+		String email = emailPrefix + "@example.com";
+		return this.userRepository.saveAndFlush(new User(
+				email,
+				this.passwordHashingService.hash("password-" + email),
+				displayName));
+	}
+
+	private Scene saveScene(Long ownerUserId, String name) throws Exception {
+		return this.sceneRepository.saveAndFlush(new Scene(
+				ownerUserId,
+				name,
+				this.objectMapper.readTree("""
+						{"visualizer":{"shader":"nebula"}}
+						""")));
+	}
+
+	private String accessToken(String email, String password) throws Exception {
+		MvcResult result = this.mockMvc.perform(post("/api/auth/login")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("{\"email\":\"" + email + "\",\"password\":\"" + password + "\"}"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.accessToken").isNotEmpty())
+				.andReturn();
+
+		Matcher matcher = Pattern.compile("\"accessToken\":\"([^\"]+)\"")
+				.matcher(result.getResponse().getContentAsString());
+		assertThat(matcher.find()).isTrue();
+		return matcher.group(1);
+	}
+
+	private static Long commentId(MvcResult result) throws Exception {
+		Matcher matcher = Pattern.compile("\"commentId\":(\\d+)")
+				.matcher(result.getResponse().getContentAsString());
+		assertThat(matcher.find()).isTrue();
+		return Long.valueOf(matcher.group(1));
+	}
+}


### PR DESCRIPTION
## Summary

- Add `scene_comments` and `scene_comment_votes` persistence.
- Add scene comment DTOs, response mapping, repository queries, and API errors.
- Add service logic for top-level comments, one-level replies, invalid parent validation, comment vote switching, and vote clearing.
- Expose comment endpoints for:
  - `GET /api/scenes/{sceneId}/comments`
  - `POST /api/scenes/{sceneId}/comments`
  - `PUT /api/scenes/{sceneId}/comments/{commentId}/vote`
  - `DELETE /api/scenes/{sceneId}/comments/{commentId}/vote`
- Add `/api/presets/{sceneId}/comments` aliases for comment reads/creation.
- Allow public comment reads with optional auth for current-user vote state.
- Return nested replies, reply counts, upvotes, downvotes, and current-user vote state.

## Testing

- `.\mvnw.cmd '-Dtest=AuthenticationInterceptorTests,SceneCommentControllerIntegrationTests' test`
- `.\mvnw.cmd '-Dtest=!*IntegrationTests,!*IntegrationTest,!MageBackendApplicationTests' test`
- `.\mvnw.cmd '-Dtest=SceneControllerIntegrationTests,UserControllerIntegrationTests,SceneCommentControllerIntegrationTests' test`
