### PR TITLE
Add authenticated change-password flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ See [docs/deployment.md](docs/deployment.md) for the expected reverse-proxy cont
 | `POST /api/auth/link/local`                 | Public       | Add local auth to an existing Google-backed account                                        |
 | `GET /api/users/me`                         | Bearer token | Return the current user profile                                                            |
 | `PUT /api/users/me`                         | Bearer token | Update the authenticated user's first name, last name, and display name                    |
+| `PUT /api/users/me/password`                | Bearer token | Change the authenticated user's local password                                              |
 | `GET /api/tags`                             | Public       | List available tags                                                                        |
 | `POST /api/tags`                            | Public       | Create a tag                                                                               |
 | `POST /api/scenes`                         | Bearer token | Create a scene with optional description and optionally finalize a staged thumbnail       |
@@ -150,6 +151,15 @@ Successful auth and profile responses return the structured personal-name fields
   "firstName": "Updated",
   "lastName": "User",
   "displayName": "Updated User"
+}
+```
+
+`PUT /api/users/me/password` accepts:
+
+```json
+{
+  "currentPassword": "current-password",
+  "newPassword": "new-password"
 }
 ```
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -86,6 +86,7 @@ If this returns `503`, the app process is alive but not ready to serve traffic.
 | `POST /api/auth/link/local`                 | Public       | Requires a valid Google ID token                                    |
 | `GET /api/users/me`                         | Bearer token | Current authenticated user                                          |
 | `PUT /api/users/me`                         | Bearer token | Updates the current user's first name, last name, and display name |
+| `PUT /api/users/me/password`                | Bearer token | Changes the current user's local password                          |
 | `GET /api/tags`                             | Public       | Returns all tags in name order                                      |
 | `POST /api/tags`                            | Public       | Tag creation is currently public                                    |
 | `POST /api/scenes`                         | Bearer token | Creates an owned scene with optional description and optionally finalizes a staged thumbnail |
@@ -108,6 +109,7 @@ If this returns `503`, the app process is alive but not ready to serve traffic.
 - `POST /api/auth/link/google`: `200` on success, `401` for invalid local credentials, `409` for account conflicts
 - `POST /api/auth/link/local`: `200` on success, `401` for invalid Google token, `409` for incompatible account state
 - `PUT /api/users/me`: `200` on success, `400` for invalid first name, last name, or display name, `401` without a valid bearer token
+- `PUT /api/users/me/password`: `204` on success, `400` for an invalid current password or invalid new password, `401` without a valid bearer token, `409` when the account does not support local authentication
 
 Registration requests must include `firstName`, `lastName`, and `displayName`. Auth and profile responses return all three fields, and `displayName` remains the public attribution field used outside authenticated profile surfaces.
 

--- a/src/main/java/com/bdmage/mage_backend/controller/UserController.java
+++ b/src/main/java/com/bdmage/mage_backend/controller/UserController.java
@@ -2,6 +2,7 @@ package com.bdmage.mage_backend.controller;
 
 import java.util.List;
 import com.bdmage.mage_backend.config.AuthenticatedUserRequest;
+import com.bdmage.mage_backend.dto.ChangePasswordRequest;
 import com.bdmage.mage_backend.dto.SceneResponse;
 import com.bdmage.mage_backend.dto.UpdateUserProfileRequest;
 import com.bdmage.mage_backend.dto.UserProfileResponse;
@@ -56,6 +57,18 @@ public class UserController {
 				request.displayName());
 
 		return ResponseEntity.ok(toUserProfileResponse(user));
+	}
+
+	@PutMapping("/me/password")
+	ResponseEntity<Void> changePassword(
+			@RequestAttribute(name = AuthenticatedUserRequest.USER_ID_ATTRIBUTE, required = false) Long authenticatedUserId,
+			@Valid @RequestBody ChangePasswordRequest request) {
+		this.userProfileService.changeAuthenticatedUserPassword(
+				authenticatedUserId,
+				request.currentPassword(),
+				request.newPassword());
+
+		return ResponseEntity.noContent().build();
 	}
 
 	private static UserProfileResponse toUserProfileResponse(User user) {

--- a/src/main/java/com/bdmage/mage_backend/dto/ChangePasswordRequest.java
+++ b/src/main/java/com/bdmage/mage_backend/dto/ChangePasswordRequest.java
@@ -1,0 +1,13 @@
+package com.bdmage.mage_backend.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record ChangePasswordRequest(
+		@NotBlank(message = "currentPassword must not be blank")
+		@Size(max = 72, message = "currentPassword must be at most 72 characters")
+		String currentPassword,
+		@NotBlank(message = "newPassword must not be blank")
+		@Size(min = 8, max = 72, message = "newPassword must be between 8 and 72 characters")
+		String newPassword) {
+}

--- a/src/main/java/com/bdmage/mage_backend/exception/ApiExceptionHandler.java
+++ b/src/main/java/com/bdmage/mage_backend/exception/ApiExceptionHandler.java
@@ -172,6 +172,30 @@ public class ApiExceptionHandler {
 				request.getRequestURI());
 	}
 
+	@ExceptionHandler(InvalidCurrentPasswordException.class)
+	ResponseEntity<ApiErrorResponse> handleInvalidCurrentPassword(
+			InvalidCurrentPasswordException ex,
+			HttpServletRequest request) {
+		return buildResponse(
+				HttpStatus.BAD_REQUEST,
+				"INVALID_CURRENT_PASSWORD",
+				ex.getMessage(),
+				Map.of(),
+				request.getRequestURI());
+	}
+
+	@ExceptionHandler(LocalPasswordChangeUnavailableException.class)
+	ResponseEntity<ApiErrorResponse> handleLocalPasswordChangeUnavailable(
+			LocalPasswordChangeUnavailableException ex,
+			HttpServletRequest request) {
+		return buildResponse(
+				HttpStatus.CONFLICT,
+				"LOCAL_PASSWORD_CHANGE_UNAVAILABLE",
+				ex.getMessage(),
+				Map.of(),
+				request.getRequestURI());
+	}
+
 	@ExceptionHandler(AuthenticationRequiredException.class)
 	ResponseEntity<ApiErrorResponse> handleAuthenticationRequired(
 			AuthenticationRequiredException ex,

--- a/src/main/java/com/bdmage/mage_backend/exception/InvalidCurrentPasswordException.java
+++ b/src/main/java/com/bdmage/mage_backend/exception/InvalidCurrentPasswordException.java
@@ -1,0 +1,8 @@
+package com.bdmage.mage_backend.exception;
+
+public class InvalidCurrentPasswordException extends RuntimeException {
+
+	public InvalidCurrentPasswordException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/bdmage/mage_backend/exception/LocalPasswordChangeUnavailableException.java
+++ b/src/main/java/com/bdmage/mage_backend/exception/LocalPasswordChangeUnavailableException.java
@@ -1,0 +1,8 @@
+package com.bdmage.mage_backend.exception;
+
+public class LocalPasswordChangeUnavailableException extends RuntimeException {
+
+	public LocalPasswordChangeUnavailableException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/bdmage/mage_backend/model/User.java
+++ b/src/main/java/com/bdmage/mage_backend/model/User.java
@@ -143,6 +143,11 @@ public class User {
 		syncAuthProvider();
 	}
 
+	public void updateLocalPassword(String passwordHash) {
+		this.passwordHash = Objects.requireNonNull(passwordHash, "passwordHash must not be null");
+		syncAuthProvider();
+	}
+
 	public void updateProfileName(String firstName, String lastName, String displayName) {
 		this.firstName = Objects.requireNonNull(firstName, "firstName must not be null");
 		this.lastName = Objects.requireNonNull(lastName, "lastName must not be null");

--- a/src/main/java/com/bdmage/mage_backend/service/UserProfileService.java
+++ b/src/main/java/com/bdmage/mage_backend/service/UserProfileService.java
@@ -1,6 +1,8 @@
 package com.bdmage.mage_backend.service;
 
 import com.bdmage.mage_backend.exception.AuthenticationRequiredException;
+import com.bdmage.mage_backend.exception.InvalidCurrentPasswordException;
+import com.bdmage.mage_backend.exception.LocalPasswordChangeUnavailableException;
 import com.bdmage.mage_backend.model.User;
 import com.bdmage.mage_backend.repository.UserRepository;
 import org.springframework.stereotype.Service;
@@ -10,11 +12,18 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserProfileService {
 
 	private static final String AUTHENTICATION_REQUIRED_MESSAGE = "Authentication is required.";
+	private static final String INVALID_CURRENT_PASSWORD_MESSAGE = "Current password is incorrect.";
+	private static final String LOCAL_PASSWORD_CHANGE_UNAVAILABLE_MESSAGE =
+			"Local password changes are not available for this account.";
 
 	private final UserRepository userRepository;
+	private final PasswordHashingService passwordHashingService;
 
-	public UserProfileService(UserRepository userRepository) {
+	public UserProfileService(
+			UserRepository userRepository,
+			PasswordHashingService passwordHashingService) {
 		this.userRepository = userRepository;
+		this.passwordHashingService = passwordHashingService;
 	}
 
 	@Transactional(readOnly = true)
@@ -36,5 +45,24 @@ public class UserProfileService {
 		User user = getAuthenticatedUser(authenticatedUserId);
 		user.updateProfileName(firstName.trim(), lastName.trim(), displayName.trim());
 		return this.userRepository.saveAndFlush(user);
+	}
+
+	@Transactional
+	public void changeAuthenticatedUserPassword(
+			Long authenticatedUserId,
+			String currentPassword,
+			String newPassword) {
+		User user = getAuthenticatedUser(authenticatedUserId);
+
+		if (!user.supportsLocalAuthentication() || user.getPasswordHash() == null) {
+			throw new LocalPasswordChangeUnavailableException(LOCAL_PASSWORD_CHANGE_UNAVAILABLE_MESSAGE);
+		}
+
+		if (!this.passwordHashingService.matches(currentPassword, user.getPasswordHash())) {
+			throw new InvalidCurrentPasswordException(INVALID_CURRENT_PASSWORD_MESSAGE);
+		}
+
+		user.updateLocalPassword(this.passwordHashingService.hash(newPassword));
+		this.userRepository.saveAndFlush(user);
 	}
 }

--- a/src/test/java/com/bdmage/mage_backend/controller/UserControllerIntegrationTests.java
+++ b/src/test/java/com/bdmage/mage_backend/controller/UserControllerIntegrationTests.java
@@ -180,6 +180,101 @@ class UserControllerIntegrationTests extends PostgresIntegrationTestSupport {
 	}
 
 	@Test
+	void changePasswordUpdatesTheStoredHashForAuthenticatedLocalUser() throws Exception {
+		String uniqueSuffix = String.valueOf(System.nanoTime());
+		String email = "password-change-" + uniqueSuffix + "@example.com";
+		String currentPassword = "current-password-" + uniqueSuffix;
+		String newPassword = "new-password-" + uniqueSuffix;
+
+		this.userRepository.saveAndFlush(new User(
+				email,
+				this.passwordHashingService.hash(currentPassword),
+				"Profile",
+				"Local",
+				"Profile Local User"));
+
+		MvcResult loginResult = this.mockMvc.perform(post("/api/auth/login")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(loginRequestBody(email, currentPassword)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.accessToken").isNotEmpty())
+				.andReturn();
+
+		String accessToken = accessToken(loginResult);
+
+		this.mockMvc.perform(put("/api/users/me/password")
+				.header("Authorization", "Bearer " + accessToken)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+						{"currentPassword":"%s","newPassword":"%s"}
+						""".formatted(currentPassword, newPassword)))
+				.andExpect(status().isNoContent());
+
+		User savedUser = this.userRepository.findByEmail(email).orElseThrow();
+		assertThat(this.passwordHashingService.matches(newPassword, savedUser.getPasswordHash())).isTrue();
+		assertThat(this.passwordHashingService.matches(currentPassword, savedUser.getPasswordHash())).isFalse();
+	}
+
+	@Test
+	void changePasswordRejectsInvalidCurrentPassword() throws Exception {
+		String uniqueSuffix = String.valueOf(System.nanoTime());
+		String email = "password-invalid-" + uniqueSuffix + "@example.com";
+		String currentPassword = "current-password-" + uniqueSuffix;
+
+		this.userRepository.saveAndFlush(new User(
+				email,
+				this.passwordHashingService.hash(currentPassword),
+				"Profile",
+				"Local",
+				"Profile Local User"));
+
+		MvcResult loginResult = this.mockMvc.perform(post("/api/auth/login")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(loginRequestBody(email, currentPassword)))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.accessToken").isNotEmpty())
+				.andReturn();
+
+		String accessToken = accessToken(loginResult);
+
+		this.mockMvc.perform(put("/api/users/me/password")
+				.header("Authorization", "Bearer " + accessToken)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+						{"currentPassword":"wrong-password","newPassword":"new-password-value"}
+						"""))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code").value("INVALID_CURRENT_PASSWORD"))
+				.andExpect(jsonPath("$.message").value("Current password is incorrect."));
+	}
+
+	@Test
+	void changePasswordRejectsGoogleOnlyAccounts() throws Exception {
+		String uniqueSuffix = String.valueOf(System.nanoTime());
+		String subject = "google-password-" + uniqueSuffix;
+		String email = "google-password-" + uniqueSuffix + "@example.com";
+
+		MvcResult authenticationResult = this.mockMvc.perform(post("/api/auth/google")
+				.contentType(MediaType.APPLICATION_JSON)
+				.content(googleRequestBody(verifiedToken(subject, email, "Profile Google User"))))
+				.andExpect(status().isCreated())
+				.andExpect(jsonPath("$.accessToken").isNotEmpty())
+				.andReturn();
+
+		String accessToken = accessToken(authenticationResult);
+
+		this.mockMvc.perform(put("/api/users/me/password")
+				.header("Authorization", "Bearer " + accessToken)
+				.contentType(MediaType.APPLICATION_JSON)
+				.content("""
+						{"currentPassword":"unused-password","newPassword":"new-password-value"}
+						"""))
+				.andExpect(status().isConflict())
+				.andExpect(jsonPath("$.code").value("LOCAL_PASSWORD_CHANGE_UNAVAILABLE"))
+				.andExpect(jsonPath("$.message").value("Local password changes are not available for this account."));
+	}
+
+	@Test
 	void scenesReturnsUnauthorizedWhenRequestHasNoAuthenticationHeader() throws Exception {
 		this.mockMvc.perform(get("/api/users/77/scenes"))
 				.andExpect(status().isUnauthorized())

--- a/src/test/java/com/bdmage/mage_backend/controller/UserControllerTests.java
+++ b/src/test/java/com/bdmage/mage_backend/controller/UserControllerTests.java
@@ -118,6 +118,31 @@ class UserControllerTests {
 	}
 
 	@Test
+	void changePasswordReturnsNoContentWhenSuccessful() throws Exception {
+		this.mockMvc.perform(put("/api/users/me/password")
+				.requestAttr(AuthenticatedUserRequest.USER_ID_ATTRIBUTE, 51L)
+				.contentType("application/json")
+				.content("""
+						{"currentPassword":"current-password","newPassword":"new-password"}
+						"""))
+				.andExpect(status().isNoContent());
+	}
+
+	@Test
+	void changePasswordRejectsInvalidRequestBody() throws Exception {
+		this.mockMvc.perform(put("/api/users/me/password")
+				.requestAttr(AuthenticatedUserRequest.USER_ID_ATTRIBUTE, 51L)
+				.contentType("application/json")
+				.content("""
+						{"currentPassword":" ","newPassword":"short"}
+						"""))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+				.andExpect(jsonPath("$.details.currentPassword").value("currentPassword must not be blank"))
+				.andExpect(jsonPath("$.details.newPassword").value("newPassword must be between 8 and 72 characters"));
+	}
+
+	@Test
 	void scenesReturnsRequestedUsersScenes() throws Exception {
 		Scene firstScene = scene(
 				15L,

--- a/src/test/java/com/bdmage/mage_backend/service/UserProfileServiceTests.java
+++ b/src/test/java/com/bdmage/mage_backend/service/UserProfileServiceTests.java
@@ -3,6 +3,8 @@ package com.bdmage.mage_backend.service;
 import java.util.Optional;
 
 import com.bdmage.mage_backend.exception.AuthenticationRequiredException;
+import com.bdmage.mage_backend.exception.InvalidCurrentPasswordException;
+import com.bdmage.mage_backend.exception.LocalPasswordChangeUnavailableException;
 import com.bdmage.mage_backend.model.User;
 import com.bdmage.mage_backend.repository.UserRepository;
 import org.junit.jupiter.api.Test;
@@ -19,7 +21,8 @@ class UserProfileServiceTests {
 	@Test
 	void getAuthenticatedUserReturnsMatchingUser() {
 		UserRepository userRepository = mock(UserRepository.class);
-		UserProfileService userProfileService = new UserProfileService(userRepository);
+		PasswordHashingService passwordHashingService = mock(PasswordHashingService.class);
+		UserProfileService userProfileService = new UserProfileService(userRepository, passwordHashingService);
 		User user = new User("user@example.com", "hashed-password", "Profile User");
 
 		when(userRepository.findById(42L)).thenReturn(Optional.of(user));
@@ -33,7 +36,8 @@ class UserProfileServiceTests {
 	@Test
 	void getAuthenticatedUserRejectsMissingRequestIdentity() {
 		UserRepository userRepository = mock(UserRepository.class);
-		UserProfileService userProfileService = new UserProfileService(userRepository);
+		PasswordHashingService passwordHashingService = mock(PasswordHashingService.class);
+		UserProfileService userProfileService = new UserProfileService(userRepository, passwordHashingService);
 
 		assertThatThrownBy(() -> userProfileService.getAuthenticatedUser(null))
 				.isInstanceOf(AuthenticationRequiredException.class)
@@ -45,7 +49,8 @@ class UserProfileServiceTests {
 	@Test
 	void getAuthenticatedUserRejectsUnknownRequestIdentity() {
 		UserRepository userRepository = mock(UserRepository.class);
-		UserProfileService userProfileService = new UserProfileService(userRepository);
+		PasswordHashingService passwordHashingService = mock(PasswordHashingService.class);
+		UserProfileService userProfileService = new UserProfileService(userRepository, passwordHashingService);
 
 		when(userRepository.findById(99L)).thenReturn(Optional.empty());
 
@@ -59,7 +64,8 @@ class UserProfileServiceTests {
 	@Test
 	void updateAuthenticatedUserProfileTrimsAndPersistsNames() {
 		UserRepository userRepository = mock(UserRepository.class);
-		UserProfileService userProfileService = new UserProfileService(userRepository);
+		PasswordHashingService passwordHashingService = mock(PasswordHashingService.class);
+		UserProfileService userProfileService = new UserProfileService(userRepository, passwordHashingService);
 		User user = new User("user@example.com", "hashed-password", "Profile", "User", "Profile User");
 
 		when(userRepository.findById(42L)).thenReturn(Optional.of(user));
@@ -76,5 +82,56 @@ class UserProfileServiceTests {
 		assertThat(updatedUser.getDisplayName()).isEqualTo("Updated Profile");
 		verify(userRepository).findById(42L);
 		verify(userRepository).saveAndFlush(user);
+	}
+
+	@Test
+	void changeAuthenticatedUserPasswordHashesAndPersistsNewPassword() {
+		UserRepository userRepository = mock(UserRepository.class);
+		PasswordHashingService passwordHashingService = mock(PasswordHashingService.class);
+		UserProfileService userProfileService = new UserProfileService(userRepository, passwordHashingService);
+		User user = new User("user@example.com", "stored-password-hash", "Profile", "User", "Profile User");
+
+		when(userRepository.findById(42L)).thenReturn(Optional.of(user));
+		when(passwordHashingService.matches("current-password", "stored-password-hash")).thenReturn(true);
+		when(passwordHashingService.hash("new-password")).thenReturn("new-password-hash");
+
+		userProfileService.changeAuthenticatedUserPassword(42L, "current-password", "new-password");
+
+		assertThat(user.getPasswordHash()).isEqualTo("new-password-hash");
+		verify(userRepository).findById(42L);
+		verify(passwordHashingService).matches("current-password", "stored-password-hash");
+		verify(passwordHashingService).hash("new-password");
+		verify(userRepository).saveAndFlush(user);
+	}
+
+	@Test
+	void changeAuthenticatedUserPasswordRejectsInvalidCurrentPassword() {
+		UserRepository userRepository = mock(UserRepository.class);
+		PasswordHashingService passwordHashingService = mock(PasswordHashingService.class);
+		UserProfileService userProfileService = new UserProfileService(userRepository, passwordHashingService);
+		User user = new User("user@example.com", "stored-password-hash", "Profile", "User", "Profile User");
+
+		when(userRepository.findById(42L)).thenReturn(Optional.of(user));
+		when(passwordHashingService.matches("wrong-password", "stored-password-hash")).thenReturn(false);
+
+		assertThatThrownBy(() ->
+				userProfileService.changeAuthenticatedUserPassword(42L, "wrong-password", "new-password"))
+				.isInstanceOf(InvalidCurrentPasswordException.class)
+				.hasMessage("Current password is incorrect.");
+	}
+
+	@Test
+	void changeAuthenticatedUserPasswordRejectsGoogleOnlyAccounts() {
+		UserRepository userRepository = mock(UserRepository.class);
+		PasswordHashingService passwordHashingService = mock(PasswordHashingService.class);
+		UserProfileService userProfileService = new UserProfileService(userRepository, passwordHashingService);
+		User user = User.google("user@example.com", "google-subject", "Profile", "User", "Profile User");
+
+		when(userRepository.findById(42L)).thenReturn(Optional.of(user));
+
+		assertThatThrownBy(() ->
+				userProfileService.changeAuthenticatedUserPassword(42L, "current-password", "new-password"))
+				.isInstanceOf(LocalPasswordChangeUnavailableException.class)
+				.hasMessage("Local password changes are not available for this account.");
 	}
 }


### PR DESCRIPTION
## Summary
- Add authenticated `PUT /api/users/me/password` for local password changes
- Require the current password before updating the stored password hash
- Validate new password length through request validation
- Reject invalid current passwords with `INVALID_CURRENT_PASSWORD`
- Reject Google-only accounts with `LOCAL_PASSWORD_CHANGE_UNAVAILABLE`
- Document the password change endpoint and add service/controller/integration coverage

## Testing
- `./mvnw.cmd test "-Dtest=UserProfileServiceTests,UserControllerTests,UserControllerIntegrationTests"`
- `./mvnw.cmd test`
